### PR TITLE
[Feature] Rename project to MeteorTest

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -118,7 +118,7 @@ test-platform
 ipa / apk / build_url
   -> 作为任务参数或 app_build 记录进入平台
 
-TestPlatform
+MeteorTest
   -> 创建任务、选择项目、套件、环境和构建产物
 
 Local Agent
@@ -130,7 +130,7 @@ iOS-Automation-Framework
 Local Agent
   -> 上传日志、截图、Allure 报告并更新任务状态
 
-TestPlatform
+MeteorTest
   -> 展示结果、趋势和 AI 分析
 ```
 
@@ -267,7 +267,7 @@ Future Cloud Farm Executor
 ### 8.2 后期标准平台架构
 
 ```text
-Test Platform
+MeteorTest
 ├── Web / Mobile UI
 ├── API Server
 ├── Task Scheduler
@@ -316,7 +316,7 @@ Local Agent / Worker
 建议新建仓库：
 
 ```text
-test-platform/
+MeteorTest/
 ├── apps/
 │   ├── web/
 │   │   ├── app/
@@ -418,7 +418,7 @@ iOS-Automation-Framework/
 - 保留测试工程职责：API/UI/性能测试、Page Object、测试数据、Allure 输出。
 - 新增平台接入协议：`test-platform.yml` 描述项目、套件、命令、环境依赖和产物目录。
 - 弱化本地 Web 控制台：`tools/webui` 只作为单项目本地调试 Demo，不作为平台中心。
-- 不在测试工程中长期放置通用 Agent。通用 Local Agent 暂时放在 `TestPlatform/agent`。
+- 不在测试工程中长期放置通用 Agent。通用 Local Agent 暂时放在 `MeteorTest/agent`。
 
 ### 11.1 新增 test-platform.yml
 
@@ -465,7 +465,7 @@ suites:
 ### 11.2 Local Agent 放在平台仓库
 
 ```text
-test-platform/agent/
+MeteorTest/agent/
 ├── agent.py
 ├── config.example.yaml
 ├── executors/
@@ -831,7 +831,7 @@ cart_api.py 里添加购物车接口是怎么调用的？
 
 目标：
 
-把 `iOS-Automation-Framework` 整理成职责单一的测试工程，并在 `TestPlatform/agent` 中跑通本地执行闭环。
+把 `iOS-Automation-Framework` 整理成职责单一的测试工程，并在 `MeteorTest/agent` 中跑通本地执行闭环。
 
 任务：
 
@@ -840,7 +840,7 @@ cart_api.py 里添加购物车接口是怎么调用的？
 - 新增 `test-platform.yml`。
 - 整理 README 中的执行说明。
 - 明确 `tools/webui` 只作为本地 Demo，不承担平台职责。
-- 在 `TestPlatform` 中新增 `agent/` 目录。
+- 在 `MeteorTest` 中新增 `agent/` 目录。
 - Agent 初期支持读取本地 JSON/SQLite 任务。
 - Agent 能调用 `iOS-Automation-Framework` 的 suite 命令并收集日志、Allure 结果。
 
@@ -868,7 +868,7 @@ cart_api.py 里添加购物车接口是怎么调用的？
 
 任务：
 
-- 将 `TestPlatform/agent` 拆为 `test-platform-agent` 独立仓库或包。
+- 将 `MeteorTest/agent` 拆为 `test-platform-agent` 独立仓库或包。
 - 支持 Agent 安装、配置、版本管理和自动升级。
 - 支持插件化执行器：pytest、Appium、Playwright、Jest、Newman、GitHub Actions。
 - 抽象 `CloudDeviceFarmExecutor`。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
-# test-platform 开发进度
+# MeteorTest 开发进度
 
 > 参考方案：`DESIGN.md`
-> 当前判断：`iOS-Automation-Framework` 只作为测试工程和接入样板；通用 Local Agent 短期放在 `TestPlatform/agent`，成熟后再独立成仓库或包。
+> 当前判断：`iOS-Automation-Framework` 只作为测试工程和接入样板；通用 Local Agent 短期放在 `MeteorTest/agent`，成熟后再独立成仓库或包。
 
 ## 短期：职责拆分与本地闭环
 
@@ -13,7 +13,7 @@
 - [x] 明确 API / UI / 性能 suite 的命令、依赖和产物路径
 - [x] 保留 `tools/webui` 作为本地 Demo，并弱化平台职责描述
 
-### Local Agent MVP（TestPlatform/agent）
+### Local Agent MVP（MeteorTest/agent）
 
 - [x] 新增 `agent/` 目录
 - [x] 支持读取测试工程的 `test-platform.yml`
@@ -28,7 +28,7 @@
 
 ### 平台 Web MVP
 
-- [x] 创建 `test-platform` 仓库目录结构
+- [x] 创建 `MeteorTest` 仓库目录结构
 - [x] 初始化 Next.js 项目（apps/web）
 - [x] 接入 Supabase Auth
 - [x] 创建数据库表（projects / test_suites / executors / tasks / reports）
@@ -71,7 +71,7 @@
 
 ### Agent 独立化
 
-- [ ] 将 `TestPlatform/agent` 拆分为 `test-platform-agent` 独立仓库或包
+- [ ] 将 `MeteorTest/agent` 拆分为 `test-platform-agent` 独立仓库或包
 - [ ] 支持 Agent 安装、配置、版本管理和自动升级
 - [ ] 支持插件化执行器：pytest、Appium、Playwright、Jest、Newman
 - [ ] 支持多机器 Agent 注册、心跳和能力管理

--- a/README.md
+++ b/README.md
@@ -1,38 +1,119 @@
-# TestPlatform
+# MeteorTest
 
-TestPlatform 是一个通用自动化测试平台，用来管理多个测试项目、创建测试任务、调度本地执行器、收集测试报告，并用 AI 辅助分析失败原因。
+<p align="center">
+  <strong>面向多项目、多套件、本地执行器和 AI 分析的自动化测试平台</strong>
+</p>
 
-当前定位是低成本 MVP：平台负责控制面和数据层，真实测试执行由 Local Agent 在本地机器完成。
+<p align="center">
+  <img alt="Next.js" src="https://img.shields.io/badge/Next.js-16-black?style=for-the-badge&logo=nextdotjs" />
+  <img alt="Supabase" src="https://img.shields.io/badge/Supabase-PostgreSQL-3ECF8E?style=for-the-badge&logo=supabase&logoColor=white" />
+  <img alt="Python" src="https://img.shields.io/badge/Python-Local_Agent-3776AB?style=for-the-badge&logo=python&logoColor=white" />
+  <img alt="AI" src="https://img.shields.io/badge/AI-DeepSeek-4B7BFF?style=for-the-badge" />
+</p>
+
+MeteorTest 是一个通用自动化测试平台，用来管理多个测试项目、导入测试套件、创建测试任务、调度本地执行器、收集测试报告，并通过 AI 辅助分析失败原因和测试结果。
+
+当前产品中文名是 **星流测试台**。`MeteorTest` 是工程和产品英文名，`test-platform.yml` 仍作为测试工程接入协议文件名保留，避免破坏既有自动化项目的接入方式。
+
+## 目录
+
+- [作者](#作者)
+- [设计初衷](#设计初衷)
+- [核心能力](#核心能力)
+- [功能矩阵](#功能矩阵)
+- [系统架构](#系统架构)
+- [项目结构](#项目结构)
+- [本地启动 Web](#本地启动-web)
+- [接入测试项目](#接入测试项目)
+- [运行 Local Agent](#运行-local-agent)
+- [推荐验证流程](#推荐验证流程)
+- [验证和 CI](#验证和-ci)
+- [成本说明](#成本说明)
+- [路线规划](#路线规划)
+
+## 作者
+
+MeteorTest 由 **流星** 发起和维护。
+
+作者长期关注客户端工程质量、自动化测试、iOS 工程体系、测试平台化和 AI 辅助研发。这个项目的目标不是做一个只展示数据的后台页面，而是把测试工程、测试任务、执行器、报告和 AI 分析串成一个可以真实落地的闭环。
+
+## 设计初衷
+
+很多自动化测试项目一开始都能跑，但后续会遇到几个典型问题：
+
+- 测试脚本散落在不同仓库，缺少统一入口。
+- 测试任务靠人工命令触发，执行记录和报告难以追踪。
+- 构建产物、测试环境、测试套件之间没有结构化关联。
+- 本地 Mac、真机、模拟器等执行资源无法被平台感知。
+- 失败日志越来越多，但真正定位问题仍然靠人工翻日志。
+- AI 能分析问题，但如果不能读取平台上下文、不能创建任务、不能查看结果，就只能停留在聊天层面。
+
+MeteorTest 的设计思路是：平台做控制面和数据层，真实执行留在本地 Local Agent；测试工程只暴露一个标准协议文件，平台不侵入业务测试代码。
+
+```text
+测试工程        MeteorTest 平台              Local Agent
+  |                 |                           |
+  | test-platform.yml                           |
+  |---------------> | 导入项目 / 套件           |
+  |                 | 创建任务 queued           |
+  |                 | <----------------------- 轮询任务
+  |                 |                           | 执行 pytest / Appium / Locust
+  |                 | <----------------------- 回传日志 / 报告 / 状态
+  |                 | AI 分析失败原因           |
+```
 
 ## 核心能力
 
 - 多项目管理：每个被测项目可绑定一个或多个自动化测试仓库。
 - 测试套件管理：通过 `test-platform.yml` 导入 API、UI、性能等 suite。
 - 构建产物管理：登记 `.ipa`、`.apk`、`.app` 或其他 build URL。
-- 任务调度：从 Web 页面创建任务，Agent 轮询并执行。
-- 执行器管理：展示 Local Agent 在线状态、能力标签和心跳。
-- 报告中心：记录日志、Allure 产物、执行摘要。
-- AI 失败分析：失败任务可调用 Claude 生成结构化分析。
-- AI 报告问答：基于最近任务、报告和分析结果进行问答。
+- 任务调度：从 Web 页面或 AI 助手创建任务，Agent 轮询并执行。
+- 执行器管理：展示 Local Agent 在线状态、能力标签、心跳和一键启动入口。
+- 报告中心：记录日志、Allure 产物、执行摘要和任务状态。
+- AI 助手：支持上下文问答、项目创建、任务创建、任务详情查询和结果分析。
+- 设置中心：支持平台名称、AI 模型、默认环境、通知策略和 Agent 启动策略配置。
 
-## 架构
+## 功能矩阵
+
+| 模块 | 当前能力 | 状态 |
+|---|---|---|
+| Dashboard | 平台概览、关键数据入口 | 已接入 |
+| 项目中心 | 创建项目、查看项目、导入 suites | 已接入 |
+| 任务中心 | 创建任务、查看状态、关联套件和环境 | 已接入 |
+| 报告中心 | 查看执行日志、报告产物和结果摘要 | 已接入 |
+| 构建产物 | 管理 App 包和构建 URL | 已接入 |
+| 执行器 | 查看 Local Agent 状态、一键启动 Agent | 已接入 |
+| AI 助手 | 聊天历史、工具调用、快捷建议、任务/项目操作 | 已接入 |
+| 设置页 | 平台名、AI 模型、默认参数、启动策略 | 已接入 |
+
+## 系统架构
 
 ```text
-Web Console (Next.js)
-  -> Supabase Auth / PostgreSQL / Storage
-  -> projects / suites / app_builds / tasks / reports / ai_analyses
-
-Local Agent (Python)
-  -> reads test-platform.yml
-  -> polls local JSON or Supabase tasks
-  -> downloads app artifacts
-  -> runs pytest / Appium / Locust commands
-  -> uploads logs and Allure results
+                    MeteorTest Web Console
+                           Next.js
+                              |
+         +--------------------+--------------------+
+         |                    |                    |
+      Supabase             AI API              Agent API
+ Auth / DB / Storage      DeepSeek            local spawn/status
+         |                    |                    |
+         |                    |                    |
+  projects / suites     context + tools      .test-platform-agent
+  builds / tasks
+  reports / analyses
+         |
+         |
+                  Local Agent (Python)
+                         |
+       +-----------------+-----------------+
+       |                 |                 |
+  test-platform.yml   app artifacts     test command
+  suite metadata      ipa/apk/app       pytest/Appium/Locust
 ```
 
 职责边界：
 
-- `TestPlatform`：平台中心，负责任务、数据、报告、AI、执行器状态。
+- `MeteorTest`：平台中心，负责任务、数据、报告、AI、执行器状态。
 - `Local Agent`：执行器，负责领取任务、准备环境、跑命令、回传结果。
 - 测试工程：只负责测试代码和 `test-platform.yml`，例如 `iOS-Automation-Framework`。
 - App 包：被测对象，例如 `.ipa`、`.apk`、内部构建链接。
@@ -40,7 +121,7 @@ Local Agent (Python)
 ## 项目结构
 
 ```text
-test-platform/
+MeteorTest/
 ├── apps/web/                 # Next.js Web 管理台
 ├── agent/                    # MVP Local Agent
 ├── docs/                     # 示例接入协议
@@ -50,7 +131,7 @@ test-platform/
 └── PROGRESS.md               # 开发进度
 ```
 
-## 本地试用 Web 页面
+## 本地启动 Web
 
 ### 1. 安装依赖
 
@@ -89,10 +170,10 @@ cp .env.local.example .env.local
 ```text
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-ANTHROPIC_API_KEY=your-anthropic-api-key
+DEEPSEEK_API_KEY=your-deepseek-api-key
 ```
 
-`ANTHROPIC_API_KEY` 是可选项。没有它时，AI 助手和失败分析不可用，但项目、任务、报告页面仍可开发调试。
+`DEEPSEEK_API_KEY` 是可选项。没有它时，AI 助手不可用，但项目、任务、报告和执行器页面仍可开发调试。
 
 ### 4. 启动 Web
 
@@ -107,15 +188,9 @@ npm run dev
 http://127.0.0.1:3000
 ```
 
-当前我已经在本机启动了 dev server，地址是：
-
-```text
-http://127.0.0.1:3000
-```
-
 注意：如果没有真实 Supabase 配置，页面会因为无法连接数据库而不可完整使用。填好 `.env.local` 后重启 `npm run dev`。
 
-## 接入一个测试项目
+## 接入测试项目
 
 测试项目根目录需要提供 `test-platform.yml`。示例见：
 
@@ -156,7 +231,7 @@ python -m pip install -r agent/requirements.txt
 
 ```bash
 cd agent
-copy config.example.yaml config.yaml
+cp config.example.yaml config.yaml
 ```
 
 配置重点：
@@ -181,8 +256,8 @@ artifacts:
 Supabase 模式需要设置：
 
 ```bash
-set SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-set SUPABASE_ARTIFACT_BUCKET=test-artifacts
+export SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+export SUPABASE_ARTIFACT_BUCKET=test-artifacts
 ```
 
 Windows PowerShell：
@@ -207,17 +282,17 @@ Agent 会：
 - 执行 suite command。
 - 写回 tasks、reports、ai_analyses。
 
-## 操作流程
+Web 执行器页面也提供 Local Agent 状态查看和一键启动入口。设置页中的启动策略可以控制进入执行器页面时是否自动启动 Agent。
 
-推荐 MVP 验证流程：
+## 推荐验证流程
 
 1. 在 Supabase 执行迁移。
 2. 启动 Web。
 3. 创建 Project，例如 `yunlu-ios`。
 4. 进入项目详情，粘贴测试工程的 `test-platform.yml` 并导入 suites。
 5. 在 Builds 页面登记 `.ipa` / `.apk` / `.app` 的 URL。
-6. 启动 Local Agent。
-7. 在 Tasks 页面创建任务，选择项目、suite、环境和构建产物。
+6. 打开执行器页面，确认 Local Agent 已启动。
+7. 在 Tasks 页面或 AI 助手中创建任务，选择项目、suite、环境和构建产物。
 8. 等待 Agent 执行。
 9. 在任务详情查看状态、日志、Allure 产物和 AI 分析。
 
@@ -278,17 +353,11 @@ MVP 阶段按低成本原则设计：
 - 定期清理旧报告和临时构建产物。
 - 等本地 Agent 闭环稳定后，再考虑云真机和高级调度。
 
-## 当前限制
+## 路线规划
 
-- Supabase RLS/权限策略还需要按真实部署环境细化。
-- Allure 目前上传的是 `allure-results.zip`，不是完整可浏览 HTML 站点。
-- AI 报告问答还没有引入 pgvector，只查询最近结构化数据。
-- Local Agent 仍在平台仓库内，尚未拆成独立安装包。
-- 云真机、智能调度、移动 WebView 入口仍未实现。
-
-## 开发进度
-
-详见：
-
-- [PROGRESS.md](./PROGRESS.md)
-- [DESIGN.md](./DESIGN.md)
+| 阶段 | 目标 |
+|---|---|
+| MVP | 跑通项目、套件、任务、Agent、报告、AI 分析闭环 |
+| Beta | 增强执行器稳定性、任务重试、报告聚合、权限控制 |
+| Team | 支持团队协作、审计日志、通知集成、更多执行资源 |
+| Cloud | 引入远程执行器、云真机、分布式调度和插件化能力 |

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,4 +1,4 @@
-# TestPlatform Local Agent
+# MeteorTest Local Agent
 
 Local Agent is the temporary platform-side executor implementation for the MVP stage.
 
@@ -47,7 +47,7 @@ Suite logs are always written locally under the configured artifact root. In Sup
 ## Relationship With iOS-Automation-Framework
 
 ```text
-TestPlatform/agent
+MeteorTest/agent
   -> reads iOS-Automation-Framework/test-platform.yml
   -> receives a task such as suite=ios_ui_smoke and app_path=/tmp/app.ipa
   -> prepares device/Appium environment

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -164,7 +164,7 @@ def run_agent(config_path: str = "config.yaml", poll_interval: int = 10):
 
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description="TestPlatform Local Agent")
+    parser = argparse.ArgumentParser(description="MeteorTest Local Agent")
     parser.add_argument("--config", default="config.yaml")
     parser.add_argument("--interval", type=int, default=10)
     args = parser.parse_args()

--- a/apps/web/app/ai/page.tsx
+++ b/apps/web/app/ai/page.tsx
@@ -7,8 +7,8 @@ type ToolResult = { ok: boolean; action?: string; data?: unknown; error?: string
 type Message = { role: 'user' | 'assistant'; content: string; suggestions?: Suggestion[]; actions?: ToolResult[] }
 type Conversation = { id: string; title: string; messages: Message[]; updatedAt: number }
 
-const historyKey = 'testplatform.ai.conversations.v1'
-const settingsKey = 'testplatform.settings.v1'
+const historyKey = 'meteortest.ai.conversations.v1'
+const settingsKey = 'meteortest.settings.v1'
 const defaultAiSettings = {
   aiModel: 'deepseek-v4-pro',
   aiBaseUrl: 'https://api.deepseek.com',
@@ -352,6 +352,7 @@ export default function AiPage() {
         const stored = JSON.parse(raw) as Conversation[]
         if (Array.isArray(stored) && stored.length > 0) {
           const sorted = stored.sort((a, b) => b.updatedAt - a.updatedAt)
+          window.localStorage.setItem(historyKey, JSON.stringify(sorted.slice(0, 30)))
           queueMicrotask(() => {
             setConversations(sorted)
             setActiveId(sorted[0].id)

--- a/apps/web/app/api/agent/status/route.ts
+++ b/apps/web/app/api/agent/status/route.ts
@@ -6,7 +6,7 @@ import { NextResponse } from 'next/server'
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const repoRoot = process.env.TEST_PLATFORM_REPO_ROOT || path.resolve(/* turbopackIgnore: true */ process.cwd(), '../..')
+const repoRoot = process.env.METEOR_TEST_REPO_ROOT || process.env.TEST_PLATFORM_REPO_ROOT || path.resolve(/* turbopackIgnore: true */ process.cwd(), '../..')
 const runtimeDir = path.join(repoRoot, '.test-platform-agent')
 const pidFile = path.join(runtimeDir, 'agent.pid')
 const logFile = path.join(runtimeDir, 'agent-web.log')
@@ -52,11 +52,11 @@ export async function POST() {
   if (current.running) return NextResponse.json({ ...current, started: false })
 
   mkdirSync(runtimeDir, { recursive: true })
-  const python = process.env.TEST_PLATFORM_AGENT_PYTHON || path.join(repoRoot, 'agent/.venv/bin/python')
+  const python = process.env.METEOR_TEST_AGENT_PYTHON || process.env.TEST_PLATFORM_AGENT_PYTHON || path.join(repoRoot, 'agent/.venv/bin/python')
   const out = openSync(logFile, 'a')
   const child = spawn(
     python,
-    ['-m', 'agent.agent', '--config', 'agent/config.yaml', '--interval', process.env.TEST_PLATFORM_AGENT_INTERVAL || '10'],
+    ['-m', 'agent.agent', '--config', 'agent/config.yaml', '--interval', process.env.METEOR_TEST_AGENT_INTERVAL || process.env.TEST_PLATFORM_AGENT_INTERVAL || '10'],
     {
       cwd: repoRoot,
       detached: true,

--- a/apps/web/app/api/ai/chat/route.ts
+++ b/apps/web/app/api/ai/chat/route.ts
@@ -406,7 +406,7 @@ export async function POST(req: NextRequest) {
     : 'https://api.deepseek.com/v1'
 
   const snapshot = await getPlatformSnapshot()
-  const systemPrompt = `你是 TestPlatform 的 AI 助手。你可以回答测试平台问题，也可以通过工具新增项目、创建测试任务、查询项目/套件/最近任务/任务详情。
+  const systemPrompt = `你是 MeteorTest 的 AI 助手。你可以回答测试平台问题，也可以通过工具新增项目、创建测试任务、查询项目/套件/最近任务/任务详情。
 规则：
 1. 回复使用用户的语言，默认中文，语气简洁。
 2. 创建项目必须确认 name 和 key；创建任务必须确认项目、测试套件和环境。

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import Sidebar from "@/components/Sidebar";
 
 export const metadata: Metadata = {
-  title: "Test Platform",
+  title: "MeteorTest",
   description: "通用自动化测试平台",
 };
 

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -21,7 +21,8 @@ type Settings = {
   density: 'comfortable' | 'compact'
 }
 
-const storageKey = 'testplatform.settings.v1'
+const storageKey = 'meteortest.settings.v1'
+const settingsUpdatedEvent = 'meteortest-settings-updated'
 
 const defaultSettings: Settings = {
   platformName: '星流测试台',
@@ -44,7 +45,7 @@ const defaultSettings: Settings = {
 
 function normalizeSettings(value: Partial<Settings>): Settings {
   const settings = { ...defaultSettings, ...value }
-  if (!settings.platformName?.trim() || settings.platformName === 'TestPlatform') {
+  if (!settings.platformName?.trim()) {
     settings.platformName = defaultSettings.platformName
   }
   if (!settings.aiModel?.trim() || settings.aiModel === 'deepseek-chat') {
@@ -107,6 +108,7 @@ export default function SettingsPage() {
     if (raw) {
       try {
         const parsed = normalizeSettings(JSON.parse(raw) as Partial<Settings>)
+        window.localStorage.setItem(storageKey, JSON.stringify(parsed))
         queueMicrotask(() => {
           setSettings(parsed)
           setSavedSettings(parsed)
@@ -134,7 +136,7 @@ export default function SettingsPage() {
   function save() {
     const normalized = normalizeSettings(settings)
     window.localStorage.setItem(storageKey, JSON.stringify(normalized))
-    window.dispatchEvent(new Event('testplatform-settings-updated'))
+    window.dispatchEvent(new Event(settingsUpdatedEvent))
     setSettings(normalized)
     setSavedSettings(normalized)
     setSavedAt(new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' }))
@@ -150,7 +152,7 @@ export default function SettingsPage() {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = 'testplatform-settings.json'
+    a.download = 'meteortest-settings.json'
     a.click()
     URL.revokeObjectURL(url)
   }

--- a/apps/web/components/AgentSupervisor.tsx
+++ b/apps/web/components/AgentSupervisor.tsx
@@ -10,7 +10,7 @@ type AgentStatus = {
   logTail: string
 }
 
-const settingsKey = 'testplatform.settings.v1'
+const settingsKey = 'meteortest.settings.v1'
 
 function shouldAutoStartAgent() {
   const raw = window.localStorage.getItem(settingsKey)

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -4,12 +4,13 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
-const settingsKey = 'testplatform.settings.v1'
+const settingsKey = 'meteortest.settings.v1'
+const settingsUpdatedEvent = 'meteortest-settings-updated'
 const defaultPlatformName = '星流测试台'
 
 function normalizePlatformName(value?: string) {
   const name = value?.trim()
-  if (!name || name === 'TestPlatform') return defaultPlatformName
+  if (!name) return defaultPlatformName
   return name
 }
 
@@ -103,10 +104,10 @@ export default function Sidebar() {
 
     queueMicrotask(loadName)
     window.addEventListener('storage', loadName)
-    window.addEventListener('testplatform-settings-updated', loadName)
+    window.addEventListener(settingsUpdatedEvent, loadName)
     return () => {
       window.removeEventListener('storage', loadName)
-      window.removeEventListener('testplatform-settings-updated', loadName)
+      window.removeEventListener(settingsUpdatedEvent, loadName)
     }
   }, [])
 

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "web",
+  "name": "meteortest-web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "web",
+      "name": "meteortest-web",
       "version": "0.1.0",
       "dependencies": {
         "@supabase/ssr": "^0.10.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "meteortest-web",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Rename the project and user-facing engineering identity from the old platform name to MeteorTest, while keeping the existing test project contract file name unchanged.

## Test Plan
- npm run lint
- npm run build
- python3 -m py_compile agent/agent.py
- rg -n "TestPlatform|testplatform|TESTPLATFORM|Test Platform" --glob "!node_modules" --glob "!.next" .

Closes #21