### PR TITLE
[Documentation] Add aligned bilingual READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,15 @@ packages/shared/          Shared TypeScript protocol types
 supabase/migrations/      Database schema migrations
 DESIGN.md                 Product and architecture design
 PROGRESS.md               Current progress and roadmap notes
-README.md                 Human-facing setup and project overview
+README.md                 English setup and project overview
+README.zh-CN.md           Simplified Chinese mirror of README.md
 ```
 
 ## Read First
 
 Before making non-trivial changes, read the relevant source plus:
 
-- `README.md` for setup, architecture, and validation flow.
+- `README.md` and `README.zh-CN.md` for setup, architecture, and validation flow.
 - `DESIGN.md` for product and protocol intent.
 - `PROGRESS.md` for current implementation status.
 - `agent/README.md` before changing Local Agent behavior.
@@ -185,6 +186,7 @@ Use these principles:
 - When changing database shape, add a new migration under `supabase/migrations/`; do not edit already-applied migrations unless the user explicitly asks for a history rewrite.
 - When changing API response shapes, check affected UI components, shared types, and Agent clients.
 - When changing Agent task lifecycle behavior, check local JSON mode and Supabase mode where applicable.
+- Keep `README.md` and `README.zh-CN.md` aligned. `README.md` is the English primary README, and `README.zh-CN.md` is the Simplified Chinese mirror. When updating either file, keep structure, claims, setup steps, limitations, roadmap, diagrams, and validation instructions equivalent. If a Chinese phrasing does not translate well, adjust the Chinese text too instead of letting the two versions diverge.
 
 ## GitHub Workflow Rules
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MeteorTest
 
 <p align="center">
-  <strong>面向多项目、多套件、本地执行器和 AI 分析的自动化测试平台</strong>
+  <strong>An automation testing platform for multiple projects, suites, local executors, and AI-assisted analysis</strong>
 </p>
 
 <p align="center">
@@ -9,85 +9,92 @@
   <img alt="Supabase" src="https://img.shields.io/badge/Supabase-PostgreSQL-3ECF8E?style=for-the-badge&logo=supabase&logoColor=white" />
   <img alt="Python" src="https://img.shields.io/badge/Python-Local_Agent-3776AB?style=for-the-badge&logo=python&logoColor=white" />
   <img alt="AI" src="https://img.shields.io/badge/AI-DeepSeek-4B7BFF?style=for-the-badge" />
+  <br />
+  <a href="https://github.com/qd1332543/iOS-Automation-Framework"><img alt="Related iOS Framework" src="https://img.shields.io/badge/Related-iOS%20Framework-555555" /></a>
+  <a href="https://github.com/qd1332543/MeteorTest/issues"><img alt="Issues" src="https://img.shields.io/badge/Links-Issues-1F6FEB" /></a>
+  <a href="#roadmap"><img alt="Roadmap" src="https://img.shields.io/badge/Links-Roadmap-8957E5" /></a>
+  <br />
+  <a href="README.md"><img alt="Docs English" src="https://img.shields.io/badge/Docs-English-black" /></a>
+  <a href="README.zh-CN.md"><img alt="Docs 中文" src="https://img.shields.io/badge/Docs-%E4%B8%AD%E6%96%87-red" /></a>
 </p>
 
-MeteorTest 是一个通用自动化测试平台，用来管理多个测试项目、导入测试套件、创建测试任务、调度本地执行器、收集测试报告，并通过 AI 辅助分析失败原因和测试结果。
+MeteorTest is a general-purpose automation testing platform for managing multiple test projects, importing test suites, creating test tasks, scheduling local executors, collecting reports, and using AI to assist with result and failure analysis.
 
-当前产品中文名是 **星流测试台**。`MeteorTest` 是工程和产品英文名，`meteortest.yml` 仍作为测试工程接入协议文件名保留，避免破坏既有自动化项目的接入方式。
+`MeteorTest` is the product and engineering name. `meteortest.yml` is the test-project integration contract used by automation repositories.
 
-## 目录
+## Table of Contents
 
-- [作者](#作者)
-- [设计初衷](#设计初衷)
-- [核心能力](#核心能力)
-- [功能矩阵](#功能矩阵)
-- [系统架构](#系统架构)
-- [项目结构](#项目结构)
-- [本地启动 Web](#本地启动-web)
-- [接入测试项目](#接入测试项目)
-- [运行 Local Agent](#运行-local-agent)
-- [推荐验证流程](#推荐验证流程)
-- [验证和 CI](#验证和-ci)
-- [成本说明](#成本说明)
-- [路线规划](#路线规划)
+- [Maintainer](#maintainer)
+- [Background](#background)
+- [Core Capabilities](#core-capabilities)
+- [Capability Overview](#capability-overview)
+- [System Architecture](#system-architecture)
+- [Project Structure](#project-structure)
+- [Start the Web Console Locally](#start-the-web-console-locally)
+- [Connect a Test Project](#connect-a-test-project)
+- [Run the Local Agent](#run-the-local-agent)
+- [Recommended Validation Flow](#recommended-validation-flow)
+- [Validation and CI](#validation-and-ci)
+- [Cost Notes](#cost-notes)
+- [Roadmap](#roadmap)
 
-## 作者
+## Maintainer
 
-MeteorTest 由 **流星** 发起和维护。
+MeteorTest is initiated and maintained by **Meteor**.
 
-作者长期关注客户端工程质量、自动化测试、iOS 工程体系、测试平台化和 AI 辅助研发。这个项目的目标不是做一个只展示数据的后台页面，而是把测试工程、测试任务、执行器、报告和 AI 分析串成一个可以真实落地的闭环。
+The project focuses on client-side engineering quality, automation testing, iOS engineering systems, test platform engineering, and AI-assisted development. The goal is not to build a dashboard that only displays data, but to connect test projects, tasks, executors, reports, and AI analysis into a practical execution loop.
 
-## 设计初衷
+## Background
 
-很多自动化测试项目一开始都能跑，但后续会遇到几个典型问题：
+Many automation projects can run successfully at the beginning, but later run into recurring problems:
 
-- 测试脚本散落在不同仓库，缺少统一入口。
-- 测试任务靠人工命令触发，执行记录和报告难以追踪。
-- 构建产物、测试环境、测试套件之间没有结构化关联。
-- 本地 Mac、真机、模拟器等执行资源无法被平台感知。
-- 失败日志越来越多，但真正定位问题仍然靠人工翻日志。
-- AI 能分析问题，但如果不能读取平台上下文、不能创建任务、不能查看结果，就只能停留在聊天层面。
+- Test scripts are scattered across repositories without a unified entry point.
+- Test tasks are triggered manually, making execution history and reports hard to track.
+- App artifacts, environments, and test suites are not linked through structured data.
+- Local Macs, devices, and simulators are not visible to a central platform.
+- Failure logs keep growing, while root-cause analysis still depends on manual log reading.
+- AI can help analyze issues, but without platform context, task creation, and report access, it remains limited to chat.
 
-MeteorTest 的设计思路是：平台做控制面和数据层，真实执行留在本地 Local Agent；测试工程只暴露一个标准协议文件，平台不侵入业务测试代码。
+MeteorTest uses the platform as the control plane and data layer, while actual test execution stays in a local Local Agent. Test projects expose a standard contract file, and the platform avoids coupling itself to project-specific test code.
 
 ```mermaid
 sequenceDiagram
-    participant Repo as 测试工程
-    participant Platform as MeteorTest 平台
+    participant Repo as Test Project
+    participant Platform as MeteorTest Platform
     participant Agent as Local Agent
 
-    Repo->>Platform: 提供 meteortest.yml
-    Platform->>Platform: 导入项目 / 套件
-    Platform->>Platform: 创建任务 queued
-    Agent->>Platform: 轮询任务
-    Agent->>Repo: 执行 pytest / Appium / Locust
-    Agent->>Platform: 回传日志 / 报告 / 状态
-    Platform->>Platform: AI 分析失败原因
+    Repo->>Platform: Provide meteortest.yml
+    Platform->>Platform: Import project / suites
+    Platform->>Platform: Create queued task
+    Agent->>Platform: Poll tasks
+    Agent->>Repo: Run pytest / Appium / Locust
+    Agent->>Platform: Upload logs / reports / status
+    Platform->>Platform: Analyze failures with AI
 ```
 
-## 核心能力
+## Core Capabilities
 
-- 多项目管理：每个被测项目可绑定一个或多个自动化测试仓库。
-- 测试套件管理：通过 `meteortest.yml` 导入 API、UI、性能等 suite。
-- 构建产物管理：登记 `.ipa`、`.apk`、`.app` 或其他 build URL。
-- 任务调度：从 Web 页面或 AI 助手创建任务，Agent 轮询并执行。
-- 执行器管理：展示 Local Agent 在线状态、能力标签、心跳和一键启动入口。
-- 报告中心：记录日志、Allure 产物、执行摘要和任务状态。
-- AI 助手：支持上下文问答、项目创建、任务创建、任务详情查询和结果分析。
-- 设置中心：支持平台名称、AI 模型、默认环境、通知策略和 Agent 启动策略配置。
+- Project management: bind each product or app to one or more automation repositories.
+- Suite management: import API, UI, performance, and other suites from `meteortest.yml`.
+- Build artifact management: register `.ipa`, `.apk`, `.app`, or other build URLs.
+- Task scheduling: create tasks from the Web console or AI assistant; agents poll and execute them.
+- Executor management: view Local Agent status, capability tags, heartbeats, and launch entry points.
+- Report center: record logs, Allure artifacts, execution summaries, and task status.
+- AI assistant: support contextual Q&A, project creation, task creation, task detail lookup, and result analysis.
+- Settings: configure platform name, AI model, default environment, notification strategy, and Agent launch behavior.
 
-## 功能矩阵
+## Capability Overview
 
-当前 MVP 的主线不是堆功能点，而是跑通一条完整的测试闭环：
+The MVP is organized around one complete testing loop rather than a flat list of screens:
 
 ```mermaid
 flowchart LR
-    Project[项目中心<br/>项目 / suites 导入]
-    Build[构建产物<br/>ipa / apk / app / URL]
-    Task[任务中心<br/>创建任务 / 选择环境]
-    Agent[执行器<br/>Local Agent 领取并执行]
-    Report[报告中心<br/>日志 / Allure / 结果摘要]
-    AI[AI 助手<br/>失败分析 / 任务查询]
+    Project[Project Center<br/>Projects / suite import]
+    Build[Build Artifacts<br/>ipa / apk / app / URL]
+    Task[Task Center<br/>Create task / select environment]
+    Agent[Executor<br/>Local Agent claims and runs tasks]
+    Report[Report Center<br/>Logs / Allure / summaries]
+    AI[AI Assistant<br/>Failure analysis / task lookup]
 
     Project --> Task
     Build --> Task
@@ -96,39 +103,39 @@ flowchart LR
     Report --> AI
 ```
 
-围绕这条闭环，当前已接入的能力包括：
+Current capabilities around this loop:
 
-- **项目中心**：创建项目、查看项目、导入 `meteortest.yml` suites。
-- **构建产物**：管理 `.ipa`、`.apk`、`.app` 和构建 URL。
-- **任务中心**：创建任务、查看状态、关联套件、环境和构建产物。
-- **执行器**：查看 Local Agent 状态、能力标签、心跳和一键启动入口。
-- **报告中心**：查看执行日志、Allure 产物、执行摘要和任务结果。
-- **AI 助手**：支持任务创建、任务详情查询、结果分析和上下文问答。
+- **Project Center**: create projects, view project details, and import `meteortest.yml` suites.
+- **Build Artifacts**: manage `.ipa`, `.apk`, `.app`, and build URLs.
+- **Task Center**: create tasks and link suites, environments, and build artifacts.
+- **Executors**: view Local Agent status, capability tags, heartbeats, and launch entry points.
+- **Report Center**: view execution logs, Allure artifacts, summaries, and task results.
+- **AI Assistant**: create tasks, query task details, analyze results, and answer contextual questions.
 
-辅助管理能力：
+Supporting management capabilities:
 
-- **Dashboard**：平台概览和关键数据入口。
-- **设置页**：平台名称、AI 模型、默认环境、通知策略和 Agent 启动策略。
+- **Dashboard**: platform overview and key entry points.
+- **Settings**: platform name, AI model, default environment, notification strategy, and Agent launch behavior.
 
-## 系统架构
+## System Architecture
 
 ```mermaid
 flowchart TB
     Web[MeteorTest Web Console<br/>Next.js]
 
-    subgraph Platform[平台控制面]
+    subgraph Platform[Platform control plane]
         Supabase[Supabase<br/>Auth / DB / Storage]
         AI[AI API<br/>DeepSeek / context + tools]
         AgentAPI[Agent API<br/>local spawn / status]
     end
 
-    subgraph Data[平台数据]
+    subgraph Data[Platform data]
         Projects[projects / suites]
         Builds[builds / tasks]
         Reports[reports / analyses]
     end
 
-    subgraph Executor[本地执行层]
+    subgraph Executor[Local execution layer]
         LocalAgent[Local Agent<br/>Python]
         Contract[meteortest.yml<br/>suite metadata]
         Artifacts[app artifacts<br/>ipa / apk / app]
@@ -149,14 +156,14 @@ flowchart TB
     LocalAgent --> Reports
 ```
 
-职责边界：
+Responsibility boundaries:
 
-- `MeteorTest`：平台中心，负责任务、数据、报告、AI、执行器状态。
-- `Local Agent`：执行器，负责领取任务、准备环境、跑命令、回传结果。
-- 测试工程：只负责测试代码和 `meteortest.yml`，例如 [`iOS-Automation-Framework`](https://github.com/qd1332543/iOS-Automation-Framework)。
-- App 包：被测对象，例如 `.ipa`、`.apk`、内部构建链接。
+- `MeteorTest`: the platform center for tasks, data, reports, AI, and executor status.
+- `Local Agent`: the executor that claims tasks, prepares artifacts, runs commands, and writes results back.
+- Test projects: own test code and `meteortest.yml`, for example [`iOS-Automation-Framework`](https://github.com/qd1332543/iOS-Automation-Framework).
+- App artifacts: the tested targets, such as `.ipa`, `.apk`, `.app`, or internal build links.
 
-## 项目结构
+## Project Structure
 
 ```text
 MeteorTest/
@@ -169,28 +176,28 @@ MeteorTest/
 └── PROGRESS.md
 ```
 
-按职责看：
+By responsibility:
 
-- `apps/web/`：Next.js Web 管理台，包含页面、组件、API routes 和 Supabase 访问。
-- `agent/`：Python Local Agent，负责轮询任务、执行 suite、收集日志和回传报告。
-- `docs/`：测试工程接入示例，重点是 `meteortest.yml` 协议文件。
-- `packages/shared/`：平台和前端复用的共享类型定义。
-- `supabase/migrations/`：数据库迁移 SQL，按编号顺序执行。
-- `DESIGN.md`：产品边界、架构设计和长期方向。
-- `PROGRESS.md`：当前实现进度和后续计划。
+- `apps/web/`: Next.js Web console, including pages, components, API routes, and Supabase access.
+- `agent/`: Python Local Agent for polling tasks, running suites, collecting logs, and reporting results.
+- `docs/`: test-project integration examples, especially the `meteortest.yml` contract.
+- `packages/shared/`: shared TypeScript protocol types.
+- `supabase/migrations/`: ordered database migration SQL files.
+- `DESIGN.md`: product boundaries, architecture design, and long-term direction.
+- `PROGRESS.md`: current implementation progress and planned work.
 
-## 本地启动 Web
+## Start the Web Console Locally
 
-### 1. 安装依赖
+### 1. Install dependencies
 
 ```bash
 cd apps/web
 npm install
 ```
 
-### 2. 创建 Supabase 项目
+### 2. Create a Supabase project
 
-在 Supabase 控制台创建一个新项目，然后在 SQL Editor 中按顺序执行：
+Create a new project in the Supabase console, then run these migrations in order in the SQL Editor:
 
 ```text
 supabase/migrations/001_init.sql
@@ -198,22 +205,22 @@ supabase/migrations/002_app_builds.sql
 supabase/migrations/003_constraints.sql
 ```
 
-如需 Agent 上传日志和 Allure 压缩包，创建一个 Storage bucket，例如：
+If the Agent needs to upload logs and zipped Allure results, create a Storage bucket, for example:
 
 ```text
 test-artifacts
 ```
 
-MVP 阶段可以先使用 public bucket，方便 Web 页面直接打开报告文件。生产环境应改成私有 bucket + 签名 URL。
+During the MVP stage, a public bucket can make report links easier to open from the Web console. For production use, switch to a private bucket with signed URLs.
 
-### 3. 配置环境变量
+### 3. Configure environment variables
 
 ```bash
 cd apps/web
 cp .env.local.example .env.local
 ```
 
-填入：
+Fill in:
 
 ```text
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
@@ -221,41 +228,41 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 DEEPSEEK_API_KEY=your-deepseek-api-key
 ```
 
-`DEEPSEEK_API_KEY` 是可选项。没有它时，AI 助手不可用，但项目、任务、报告和执行器页面仍可开发调试。
+`DEEPSEEK_API_KEY` is optional. Without it, the AI assistant is unavailable, but projects, tasks, reports, and executor pages can still be developed and tested.
 
-### 4. 启动 Web
+### 4. Start the Web console
 
 ```bash
 cd apps/web
 npm run dev
 ```
 
-访问：
+Open:
 
 ```text
 http://127.0.0.1:3000
 ```
 
-注意：如果没有真实 Supabase 配置，页面会因为无法连接数据库而不可完整使用。填好 `.env.local` 后重启 `npm run dev`。
+If real Supabase settings are missing, the page cannot fully connect to the database. After updating `.env.local`, restart `npm run dev`.
 
-## 接入测试项目
+## Connect a Test Project
 
-测试项目根目录需要提供 `meteortest.yml`。示例见：
+A test project should provide `meteortest.yml` at its repository root. See:
 
 ```text
 docs/meteortest.example.yml
 ```
 
-最小结构：
+Minimum structure:
 
 ```yaml
 project:
   key: yunlu-ios
-  name: 云鹿商城 iOS
+  name: Yunlu Mall iOS
 
 suites:
   - id: api_smoke
-    name: API 冒烟测试
+    name: API smoke test
     type: api
     command: python -m pytest API_Automation/cases -v --alluredir=Reports/platform/{task_id}/allure-results
     requires:
@@ -265,28 +272,28 @@ suites:
       allure: true
 ```
 
-平台导入 suite 时兼容 `id`、`key`、`suite_key` 三种字段。
+Suite import supports `id`, `key`, and `suite_key` as compatible suite identifiers.
 
-## 运行 Local Agent
+## Run the Local Agent
 
-### 1. 安装 Agent 依赖
+### 1. Install Agent dependencies
 
 ```bash
 python -m pip install -r agent/requirements.txt
 ```
 
-### 2. 准备配置
+### 2. Prepare configuration
 
 ```bash
 cd agent
 cp config.example.yaml config.yaml
 ```
 
-配置重点：
+Important fields:
 
 ```yaml
 platform:
-  mode: local        # local 或 supabase
+  mode: local        # local or supabase
   local_task_store: .meteortest-agent/tasks.json
   supabase_url: https://your-project.supabase.co
   supabase_service_role_key_env: SUPABASE_SERVICE_ROLE_KEY
@@ -301,58 +308,58 @@ artifacts:
   supabase_bucket: test-artifacts
 ```
 
-Supabase 模式需要设置：
+Supabase mode requires:
 
 ```bash
 export SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 export SUPABASE_ARTIFACT_BUCKET=test-artifacts
 ```
 
-Windows PowerShell：
+Windows PowerShell:
 
 ```powershell
 $env:SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 $env:SUPABASE_ARTIFACT_BUCKET="test-artifacts"
 ```
 
-### 3. 启动 Agent
+### 3. Start the Agent
 
 ```bash
 python -m agent.agent --config agent/config.yaml --interval 10
 ```
 
-Agent 会：
+The Agent will:
 
-- 注册或更新 executor。
-- 轮询 queued 任务。
-- 锁定任务并置为 running。
-- 下载任务关联的 app build。
-- 执行 suite command。
-- 写回 tasks、reports、ai_analyses。
+- Register or update the executor.
+- Poll queued tasks.
+- Lock tasks and move them to running.
+- Download the app build attached to a task.
+- Run the suite command.
+- Write back tasks, reports, and AI analysis records.
 
-Web 执行器页面也提供 Local Agent 状态查看和一键启动入口。设置页中的启动策略可以控制进入执行器页面时是否自动启动 Agent。
+The Web executor page also shows Local Agent status and provides a launch entry point. The Settings page can control whether the Agent starts automatically when the executor page is opened.
 
-## 推荐验证流程
+## Recommended Validation Flow
 
-1. 在 Supabase 执行迁移。
-2. 启动 Web。
-3. 创建 Project，例如 `yunlu-ios`。
-4. 进入项目详情，粘贴测试工程的 `meteortest.yml` 并导入 suites。
-5. 在 Builds 页面登记 `.ipa` / `.apk` / `.app` 的 URL。
-6. 打开执行器页面，确认 Local Agent 已启动。
-7. 在 Tasks 页面或 AI 助手中创建任务，选择项目、suite、环境和构建产物。
-8. 等待 Agent 执行。
-9. 在任务详情查看状态、日志、Allure 产物和 AI 分析。
+1. Run Supabase migrations.
+2. Start the Web console.
+3. Create a project, for example `yunlu-ios`.
+4. Open the project detail page, paste the test project's `meteortest.yml`, and import suites.
+5. Register an `.ipa`, `.apk`, `.app`, or build URL on the Builds page.
+6. Open the Executors page and confirm the Local Agent is running.
+7. Create a task from the Tasks page or AI assistant, selecting project, suite, environment, and build artifact.
+8. Wait for the Agent to execute it.
+9. Open task details to inspect status, logs, Allure artifacts, and AI analysis.
 
-## 验证和 CI
+## Validation and CI
 
-本仓库包含 GitHub Actions CI：
+This repository includes GitHub Actions CI:
 
 ```text
 .github/workflows/ci.yml
 ```
 
-PR 会自动运行：
+Pull requests run:
 
 ```bash
 cd apps/web
@@ -361,7 +368,7 @@ npm run lint
 npm run build
 ```
 
-以及：
+And:
 
 ```bash
 python -m pip install -r agent/requirements.txt
@@ -369,7 +376,7 @@ python -m compileall agent
 python -m pytest agent/tests -q
 ```
 
-本地手动验证：
+Local manual validation:
 
 ```bash
 python -m pytest agent/tests -q
@@ -379,36 +386,36 @@ npm run lint
 npm run build
 ```
 
-## 成本说明
+## Cost Notes
 
-MVP 阶段按低成本原则设计：
+The MVP is designed with low operating cost in mind:
 
-- Web 可以部署在 Vercel 免费额度内。
-- 数据库和 Storage 可以先使用 Supabase 免费额度。
-- iOS UI 自动化优先使用本地 Mac Agent，不依赖云真机。
-- AI 能力按量调用，建议只对 failed / timeout 任务触发。
+- The Web console can be deployed within Vercel's free tier.
+- Database and Storage can start on Supabase's free tier.
+- iOS UI automation should prefer a local Mac Agent first, without depending on cloud devices.
+- AI usage is pay-as-you-go; triggering analysis only for failed or timeout tasks is recommended.
 
-需要关注的成本来源：
+Cost areas to watch:
 
-- 测试报告和日志的 Storage 体积。
-- AI 分析的调用次数和日志长度。
-- 云真机、专用 CI Runner、团队级 Vercel/Supabase 套餐。
+- Storage size for reports and logs.
+- Number of AI analysis calls and the amount of log text sent for analysis.
+- Cloud devices, dedicated CI runners, and team-level Vercel or Supabase plans.
 
-成本控制建议：
+Cost control suggestions:
 
-- 数据库只保存报告索引，不保存大文件正文。
-- 日志上传前截断或压缩，AI 分析只取失败片段。
-- 定期清理旧报告和临时构建产物。
-- 等本地 Agent 闭环稳定后，再考虑云真机和高级调度。
+- Store report indexes in the database instead of large file bodies.
+- Truncate or compress logs before upload, and send only relevant failure snippets to AI analysis.
+- Clean up old reports and temporary build artifacts regularly.
+- Consider cloud devices and advanced scheduling only after the local Agent loop is stable.
 
-## 路线规划
+## Roadmap
 
 ```mermaid
 flowchart LR
-    MVP[MVP<br/>项目 / 套件 / 任务 / Agent / 报告 / AI 分析闭环]
-    Beta[Beta<br/>执行器稳定性 / 任务重试 / 报告聚合 / 权限控制]
-    Team[Team<br/>团队协作 / 审计日志 / 通知集成 / 更多执行资源]
-    Cloud[Cloud<br/>远程执行器 / 云真机 / 分布式调度 / 插件化]
+    MVP[MVP<br/>Projects / suites / tasks / Agent / reports / AI analysis loop]
+    Beta[Beta<br/>Executor stability / retries / report aggregation / permissions]
+    Team[Team<br/>Collaboration / audit logs / notifications / more execution resources]
+    Cloud[Cloud<br/>Remote executors / cloud devices / distributed scheduling / plugins]
 
     MVP --> Beta --> Team --> Cloud
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,421 @@
+# MeteorTest
+
+<p align="center">
+  <strong>面向多项目、多套件、本地执行器和 AI 辅助分析的自动化测试平台</strong>
+</p>
+
+<p align="center">
+  <img alt="Next.js" src="https://img.shields.io/badge/Next.js-16-black?style=for-the-badge&logo=nextdotjs" />
+  <img alt="Supabase" src="https://img.shields.io/badge/Supabase-PostgreSQL-3ECF8E?style=for-the-badge&logo=supabase&logoColor=white" />
+  <img alt="Python" src="https://img.shields.io/badge/Python-Local_Agent-3776AB?style=for-the-badge&logo=python&logoColor=white" />
+  <img alt="AI" src="https://img.shields.io/badge/AI-DeepSeek-4B7BFF?style=for-the-badge" />
+  <br />
+  <a href="https://github.com/qd1332543/iOS-Automation-Framework"><img alt="Related iOS Framework" src="https://img.shields.io/badge/Related-iOS%20Framework-555555" /></a>
+  <a href="https://github.com/qd1332543/MeteorTest/issues"><img alt="Issues" src="https://img.shields.io/badge/Links-Issues-1F6FEB" /></a>
+  <a href="#路线规划"><img alt="Roadmap" src="https://img.shields.io/badge/Links-Roadmap-8957E5" /></a>
+  <br />
+  <a href="README.md"><img alt="Docs English" src="https://img.shields.io/badge/Docs-English-black" /></a>
+  <a href="README.zh-CN.md"><img alt="Docs 中文" src="https://img.shields.io/badge/Docs-%E4%B8%AD%E6%96%87-red" /></a>
+</p>
+
+MeteorTest 是一个通用自动化测试平台，用来管理多个测试项目、导入测试套件、创建测试任务、调度本地执行器、收集测试报告，并通过 AI 辅助分析测试结果和失败原因。
+
+当前产品中文名是 **星流测试台**。`MeteorTest` 是工程和产品英文名。`meteortest.yml` 是自动化测试仓库接入平台时使用的测试项目协议文件。
+
+## 目录
+
+- [维护者](#维护者)
+- [背景](#背景)
+- [核心能力](#核心能力)
+- [能力概览](#能力概览)
+- [系统架构](#系统架构)
+- [项目结构](#项目结构)
+- [本地启动 Web 控制台](#本地启动-web-控制台)
+- [接入测试项目](#接入测试项目)
+- [运行 Local Agent](#运行-local-agent)
+- [推荐验证流程](#推荐验证流程)
+- [验证和 CI](#验证和-ci)
+- [成本说明](#成本说明)
+- [路线规划](#路线规划)
+
+## 维护者
+
+MeteorTest 由 **流星（Meteor）** 发起和维护。
+
+这个项目关注客户端工程质量、自动化测试、iOS 工程体系、测试平台化和 AI 辅助研发。目标不是做一个只展示数据的后台页面，而是把测试工程、测试任务、执行器、报告和 AI 分析连接成一个可以真实落地的执行闭环。
+
+## 背景
+
+很多自动化测试项目一开始可以顺利运行，但后续会遇到一些反复出现的问题：
+
+- 测试脚本散落在不同仓库，缺少统一入口。
+- 测试任务靠人工命令触发，执行记录和报告难以追踪。
+- App 构建产物、测试环境、测试套件之间没有结构化关联。
+- 本地 Mac、真机、模拟器等执行资源无法被平台感知。
+- 失败日志持续增长，但定位原因仍然依赖人工阅读日志。
+- AI 可以辅助分析问题，但如果不能读取平台上下文、不能创建任务、不能查看报告，就只能停留在聊天层面。
+
+MeteorTest 的设计思路是：平台负责控制面和数据层，真实测试执行留在本地 Local Agent；测试项目通过标准协议文件暴露能力，平台不直接耦合具体项目的测试代码。
+
+```mermaid
+sequenceDiagram
+    participant Repo as 测试项目
+    participant Platform as MeteorTest 平台
+    participant Agent as Local Agent
+
+    Repo->>Platform: 提供 meteortest.yml
+    Platform->>Platform: 导入项目 / suites
+    Platform->>Platform: 创建 queued 任务
+    Agent->>Platform: 轮询任务
+    Agent->>Repo: 执行 pytest / Appium / Locust
+    Agent->>Platform: 回传日志 / 报告 / 状态
+    Platform->>Platform: AI 分析失败原因
+```
+
+## 核心能力
+
+- 项目管理：将每个产品或 App 绑定到一个或多个自动化测试仓库。
+- 套件管理：通过 `meteortest.yml` 导入 API、UI、性能等 suite。
+- 构建产物管理：登记 `.ipa`、`.apk`、`.app` 或其他构建 URL。
+- 任务调度：从 Web 控制台或 AI 助手创建任务，Agent 轮询并执行。
+- 执行器管理：查看 Local Agent 在线状态、能力标签、心跳和启动入口。
+- 报告中心：记录日志、Allure 产物、执行摘要和任务状态。
+- AI 助手：支持上下文问答、项目创建、任务创建、任务详情查询和结果分析。
+- 设置中心：配置平台名称、AI 模型、默认环境、通知策略和 Agent 启动策略。
+
+## 能力概览
+
+MVP 围绕一条完整测试闭环组织，而不是平铺功能页面：
+
+```mermaid
+flowchart LR
+    Project[项目中心<br/>项目 / suite 导入]
+    Build[构建产物<br/>ipa / apk / app / URL]
+    Task[任务中心<br/>创建任务 / 选择环境]
+    Agent[执行器<br/>Local Agent 领取并执行]
+    Report[报告中心<br/>日志 / Allure / 摘要]
+    AI[AI 助手<br/>失败分析 / 任务查询]
+
+    Project --> Task
+    Build --> Task
+    Task --> Agent
+    Agent --> Report
+    Report --> AI
+```
+
+围绕这条闭环，当前能力包括：
+
+- **项目中心**：创建项目、查看项目详情、导入 `meteortest.yml` suites。
+- **构建产物**：管理 `.ipa`、`.apk`、`.app` 和构建 URL。
+- **任务中心**：创建任务，并关联 suite、环境和构建产物。
+- **执行器**：查看 Local Agent 状态、能力标签、心跳和启动入口。
+- **报告中心**：查看执行日志、Allure 产物、执行摘要和任务结果。
+- **AI 助手**：创建任务、查询任务详情、分析结果和进行上下文问答。
+
+辅助管理能力：
+
+- **Dashboard**：平台概览和关键入口。
+- **设置页**：平台名称、AI 模型、默认环境、通知策略和 Agent 启动策略。
+
+## 系统架构
+
+```mermaid
+flowchart TB
+    Web[MeteorTest Web 控制台<br/>Next.js]
+
+    subgraph Platform[平台控制面]
+        Supabase[Supabase<br/>Auth / DB / Storage]
+        AI[AI API<br/>DeepSeek / context + tools]
+        AgentAPI[Agent API<br/>local spawn / status]
+    end
+
+    subgraph Data[平台数据]
+        Projects[projects / suites]
+        Builds[builds / tasks]
+        Reports[reports / analyses]
+    end
+
+    subgraph Executor[本地执行层]
+        LocalAgent[Local Agent<br/>Python]
+        Contract[meteortest.yml<br/>suite metadata]
+        Artifacts[app artifacts<br/>ipa / apk / app]
+        Command[test command<br/>pytest / Appium / Locust]
+    end
+
+    Web --> Supabase
+    Web --> AI
+    Web --> AgentAPI
+    Supabase --> Projects
+    Supabase --> Builds
+    Supabase --> Reports
+    Builds --> LocalAgent
+    AgentAPI --> LocalAgent
+    LocalAgent --> Contract
+    LocalAgent --> Artifacts
+    LocalAgent --> Command
+    LocalAgent --> Reports
+```
+
+职责边界：
+
+- `MeteorTest`：平台中心，负责任务、数据、报告、AI 和执行器状态。
+- `Local Agent`：执行器，负责领取任务、准备构建产物、执行命令并回写结果。
+- 测试项目：负责测试代码和 `meteortest.yml`，例如 [`iOS-Automation-Framework`](https://github.com/qd1332543/iOS-Automation-Framework)。
+- App 构建产物：被测对象，例如 `.ipa`、`.apk`、`.app` 或内部构建链接。
+
+## 项目结构
+
+```text
+MeteorTest/
+├── apps/web/
+├── agent/
+├── docs/
+├── packages/shared/
+├── supabase/migrations/
+├── DESIGN.md
+└── PROGRESS.md
+```
+
+按职责看：
+
+- `apps/web/`：Next.js Web 控制台，包含页面、组件、API routes 和 Supabase 访问。
+- `agent/`：Python Local Agent，负责轮询任务、执行 suite、收集日志并回传结果。
+- `docs/`：测试项目接入示例，重点是 `meteortest.yml` 协议。
+- `packages/shared/`：共享的 TypeScript 协议类型。
+- `supabase/migrations/`：按顺序执行的数据库迁移 SQL。
+- `DESIGN.md`：产品边界、架构设计和长期方向。
+- `PROGRESS.md`：当前实现进度和后续计划。
+
+## 本地启动 Web 控制台
+
+### 1. 安装依赖
+
+```bash
+cd apps/web
+npm install
+```
+
+### 2. 创建 Supabase 项目
+
+在 Supabase 控制台创建新项目，然后在 SQL Editor 中按顺序执行：
+
+```text
+supabase/migrations/001_init.sql
+supabase/migrations/002_app_builds.sql
+supabase/migrations/003_constraints.sql
+```
+
+如果 Agent 需要上传日志和 Allure 压缩包，创建一个 Storage bucket，例如：
+
+```text
+test-artifacts
+```
+
+MVP 阶段可以先使用 public bucket，方便 Web 控制台直接打开报告链接。生产环境应改成私有 bucket，并使用签名 URL。
+
+### 3. 配置环境变量
+
+```bash
+cd apps/web
+cp .env.local.example .env.local
+```
+
+填入：
+
+```text
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+DEEPSEEK_API_KEY=your-deepseek-api-key
+```
+
+`DEEPSEEK_API_KEY` 是可选项。没有它时，AI 助手不可用，但项目、任务、报告和执行器页面仍可开发和调试。
+
+### 4. 启动 Web 控制台
+
+```bash
+cd apps/web
+npm run dev
+```
+
+打开：
+
+```text
+http://127.0.0.1:3000
+```
+
+如果没有真实 Supabase 配置，页面无法完整连接数据库。更新 `.env.local` 后，需要重启 `npm run dev`。
+
+## 接入测试项目
+
+测试项目需要在仓库根目录提供 `meteortest.yml`。示例见：
+
+```text
+docs/meteortest.example.yml
+```
+
+最小结构：
+
+```yaml
+project:
+  key: yunlu-ios
+  name: Yunlu Mall iOS
+
+suites:
+  - id: api_smoke
+    name: API smoke test
+    type: api
+    command: python -m pytest API_Automation/cases -v --alluredir=Reports/platform/{task_id}/allure-results
+    requires:
+      - python
+      - pytest
+    report:
+      allure: true
+```
+
+导入 suite 时兼容 `id`、`key`、`suite_key` 三种 suite 标识字段。
+
+## 运行 Local Agent
+
+### 1. 安装 Agent 依赖
+
+```bash
+python -m pip install -r agent/requirements.txt
+```
+
+### 2. 准备配置
+
+```bash
+cd agent
+cp config.example.yaml config.yaml
+```
+
+关键配置：
+
+```yaml
+platform:
+  mode: local        # local or supabase
+  local_task_store: .meteortest-agent/tasks.json
+  supabase_url: https://your-project.supabase.co
+  supabase_service_role_key_env: SUPABASE_SERVICE_ROLE_KEY
+
+repositories:
+  - key: yunlu-ios
+    path: ../iOS-Automation-Framework
+    contract: meteortest.yml
+
+artifacts:
+  local_output_root: .meteortest-agent/artifacts
+  supabase_bucket: test-artifacts
+```
+
+Supabase 模式需要设置：
+
+```bash
+export SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+export SUPABASE_ARTIFACT_BUCKET=test-artifacts
+```
+
+Windows PowerShell：
+
+```powershell
+$env:SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+$env:SUPABASE_ARTIFACT_BUCKET="test-artifacts"
+```
+
+### 3. 启动 Agent
+
+```bash
+python -m agent.agent --config agent/config.yaml --interval 10
+```
+
+Agent 会：
+
+- 注册或更新 executor。
+- 轮询 queued 任务。
+- 锁定任务并置为 running。
+- 下载任务关联的 app build。
+- 执行 suite command。
+- 写回 tasks、reports 和 ai_analyses。
+
+Web 执行器页面也会展示 Local Agent 状态，并提供启动入口。设置页可以控制打开执行器页面时是否自动启动 Agent。
+
+## 推荐验证流程
+
+1. 执行 Supabase 迁移。
+2. 启动 Web 控制台。
+3. 创建项目，例如 `yunlu-ios`。
+4. 打开项目详情，粘贴测试项目的 `meteortest.yml` 并导入 suites。
+5. 在 Builds 页面登记 `.ipa`、`.apk`、`.app` 或构建 URL。
+6. 打开 Executors 页面，确认 Local Agent 正在运行。
+7. 在 Tasks 页面或 AI 助手中创建任务，选择项目、suite、环境和构建产物。
+8. 等待 Agent 执行。
+9. 打开任务详情，查看状态、日志、Allure 产物和 AI 分析。
+
+## 验证和 CI
+
+本仓库包含 GitHub Actions CI：
+
+```text
+.github/workflows/ci.yml
+```
+
+Pull request 会运行：
+
+```bash
+cd apps/web
+npm ci
+npm run lint
+npm run build
+```
+
+以及：
+
+```bash
+python -m pip install -r agent/requirements.txt
+python -m compileall agent
+python -m pytest agent/tests -q
+```
+
+本地手动验证：
+
+```bash
+python -m pytest agent/tests -q
+python -m compileall agent
+cd apps/web
+npm run lint
+npm run build
+```
+
+## 成本说明
+
+MVP 按低运行成本设计：
+
+- Web 控制台可以部署在 Vercel 免费额度内。
+- 数据库和 Storage 可以先使用 Supabase 免费额度。
+- iOS UI 自动化优先使用本地 Mac Agent，不依赖云真机。
+- AI 能力按量调用，建议只对 failed 或 timeout 任务触发分析。
+
+需要关注的成本来源：
+
+- 报告和日志的 Storage 体积。
+- AI 分析调用次数，以及发送给 AI 的日志文本长度。
+- 云真机、专用 CI runner、团队级 Vercel 或 Supabase 套餐。
+
+成本控制建议：
+
+- 数据库保存报告索引，不保存大文件正文。
+- 日志上传前截断或压缩，AI 分析只发送相关失败片段。
+- 定期清理旧报告和临时构建产物。
+- 本地 Agent 闭环稳定后，再考虑云真机和高级调度。
+
+## 路线规划
+
+```mermaid
+flowchart LR
+    MVP[MVP<br/>项目 / suite / 任务 / Agent / 报告 / AI 分析闭环]
+    Beta[Beta<br/>执行器稳定性 / 重试 / 报告聚合 / 权限]
+    Team[Team<br/>团队协作 / 审计日志 / 通知 / 更多执行资源]
+    Cloud[Cloud<br/>远程执行器 / 云真机 / 分布式调度 / 插件化]
+
+    MVP --> Beta --> Team --> Cloud
+```


### PR DESCRIPTION
## Summary
Make the public README experience bilingual and consistent. README.md is now the English primary README, while README.zh-CN.md mirrors the same structure, claims, setup steps, diagrams, roadmap, and validation guidance in Simplified Chinese.

## Proposed Changes
- Convert README.md to English as the primary GitHub README.
- Add README.zh-CN.md as the Simplified Chinese mirror.
- Add top-level badges for related links, issues, roadmap, and documentation language switching.
- Keep the feature overview, architecture, project structure, and roadmap aligned across both languages.
- Add AGENTS.md guidance requiring future README updates to keep both language versions synchronized.

## Test Plan
- Documentation-only change; no runtime tests were run.
- Ran git diff --check.
- Previewed the README from the fork branch on GitHub.

Closes #27