### PR TITLE
[Feature] Use test repository Python runtime in Local Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ suites:
 
 Suite import supports `id`, `key`, and `suite_key` as compatible suite identifiers.
 
+When a suite command starts with `python` or `python3`, the Local Agent treats the test repository as the runtime owner. It resolves the Python executable in this order:
+
+1. `parameters.python_executable` from the task.
+2. `METEORTEST_TEST_PYTHON` from the Agent environment.
+3. `.venv` or `venv` inside the test repository.
+4. The original `python` or `python3` command if no project-specific runtime is found.
+
+This keeps platform execution isolated from the Agent's own Python environment. For Windows test repositories, prefer a project-local virtual environment so pytest plugins such as `pytest-xdist`, `pytest-rerunfailures`, and `allure-pytest` are resolved consistently.
+
 ## Run the Local Agent
 
 ### 1. Install Agent dependencies

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -274,6 +274,15 @@ suites:
 
 导入 suite 时兼容 `id`、`key`、`suite_key` 三种 suite 标识字段。
 
+当 suite command 以 `python` 或 `python3` 开头时，Local Agent 会把测试仓库视为运行时所有者，并按以下顺序解析 Python 可执行文件：
+
+1. 任务中的 `parameters.python_executable`。
+2. Agent 环境变量 `METEORTEST_TEST_PYTHON`。
+3. 测试仓库内的 `.venv` 或 `venv`。
+4. 如果没有找到项目专属运行时，则保留原始 `python` 或 `python3` 命令。
+
+这样可以避免平台 Agent 自己的 Python 环境污染测试仓库。Windows 测试仓库建议使用项目内虚拟环境，确保 `pytest-xdist`、`pytest-rerunfailures`、`allure-pytest` 等插件解析一致。
+
 ## 运行 Local Agent
 
 ### 1. 安装 Agent 依赖

--- a/agent/README.md
+++ b/agent/README.md
@@ -16,6 +16,17 @@ It is responsible for:
 
 It is not owned by individual test repositories. Test repositories only expose suite metadata and executable commands.
 
+## Test Repository Runtime
+
+The Agent should not force suite commands to run with the Agent's own Python interpreter. When a command starts with `python` or `python3`, the executor resolves the test runtime in this order:
+
+1. `parameters.python_executable` from the task.
+2. `METEORTEST_TEST_PYTHON` from the Agent environment.
+3. `.venv` or `venv` inside the test repository.
+4. The original command token if no project runtime is found.
+
+This keeps platform dependencies separate from pytest/Appium/Locust dependencies owned by the test project.
+
 ## MVP Layout
 
 ```text

--- a/agent/executors/pytest_executor.py
+++ b/agent/executors/pytest_executor.py
@@ -4,7 +4,6 @@ pytest_executor.py - 执行 suite 命令并收集日志和 Allure 结果
 import subprocess
 import shlex
 import os
-import sys
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -22,6 +21,40 @@ def _split_command(command: str) -> list[str]:
     if os.name == "nt":
         return shlex.split(command, posix=False)
     return shlex.split(command)
+
+
+def _repo_python_candidates(repo_path: str) -> list[Path]:
+    repo = Path(repo_path)
+    if os.name == "nt":
+        return [
+            repo / ".venv" / "Scripts" / "python.exe",
+            repo / "venv" / "Scripts" / "python.exe",
+        ]
+    return [
+        repo / ".venv" / "bin" / "python",
+        repo / "venv" / "bin" / "python",
+    ]
+
+
+def _resolve_python_executable(repo_path: str, parameters: dict) -> str | None:
+    configured = parameters.get("python_executable") or os.environ.get("METEORTEST_TEST_PYTHON")
+    if configured:
+        return str(configured)
+    for candidate in _repo_python_candidates(repo_path):
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def _prepare_command(command: str, repo_path: str, parameters: dict) -> list[str]:
+    tokens = _split_command(command)
+    if not tokens:
+        return tokens
+    if tokens[0] in {"python", "python3"}:
+        python_executable = _resolve_python_executable(repo_path, parameters)
+        if python_executable:
+            tokens[0] = python_executable
+    return tokens
 
 
 def run_suite(suite: dict, repo_path: str, output_dir: str, task_id: str,
@@ -43,16 +76,6 @@ def run_suite(suite: dict, repo_path: str, output_dir: str, task_id: str,
         **parameters,
     }
     command = _format_command(suite["command"], format_values)
-    # Use the current interpreter for python commands so local agents work on
-    # Windows, macOS, and CI without depending on shell aliases.
-    if command.startswith("python "):
-        command = sys.executable + command[6:]
-    elif command == "python":
-        command = sys.executable
-    elif command.startswith("python3 "):
-        command = sys.executable + command[7:]
-    elif command == "python3":
-        command = sys.executable
 
     # 如果 suite 有 allure 报告且命令未显式声明 --alluredir，则注入默认目录。
     allure_dir = None
@@ -60,6 +83,8 @@ def run_suite(suite: dict, repo_path: str, output_dir: str, task_id: str,
         allure_dir = str(out_path / "allure-results")
         if "--alluredir" not in command:
             command = f"{command} --alluredir={allure_dir}"
+
+    command_tokens = _prepare_command(command, repo_path, parameters)
 
     env = os.environ.copy()
     env.update({
@@ -74,7 +99,7 @@ def run_suite(suite: dict, repo_path: str, output_dir: str, task_id: str,
     started_at = datetime.now(timezone.utc).isoformat()
     with open(log_file, "w", encoding="utf-8") as f:
         result = subprocess.run(
-            _split_command(command),
+            command_tokens,
             cwd=repo_path,
             stdout=f,
             stderr=subprocess.STDOUT,

--- a/agent/tests/test_local_agent_smoke.py
+++ b/agent/tests/test_local_agent_smoke.py
@@ -1,9 +1,11 @@
 import json
+import sys
 import threading
 import time
 from pathlib import Path
 
 from agent.agent import run_agent
+from agent.executors.pytest_executor import _prepare_command
 
 
 def _write_sample_repo(repo_path: Path) -> None:
@@ -55,7 +57,7 @@ def test_local_agent_executes_task_and_writes_report(tmp_path):
                     "suite_id": "smoke",
                     "environment": "staging",
                     "status": "queued",
-                    "parameters": {},
+                    "parameters": {"python_executable": sys.executable},
                     "created_at": "2026-04-30T00:00:00Z",
                     "started_at": None,
                     "finished_at": None,
@@ -110,3 +112,28 @@ artifacts:
     assert log_path.exists()
     assert "1 passed" in log_path.read_text(encoding="utf-8")
     assert Path(task["report"]["allure_results_path"]).exists()
+
+
+def test_python_command_prefers_test_repo_virtualenv(tmp_path):
+    repo_path = tmp_path / "sample-repo"
+    python_path = repo_path / ".venv" / "Scripts" / "python.exe"
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("", encoding="utf-8")
+
+    command = _prepare_command("python -m pytest tests", str(repo_path), {})
+
+    assert command[0] == str(python_path)
+    assert command[1:] == ["-m", "pytest", "tests"]
+
+
+def test_python_command_can_be_configured_per_task(tmp_path):
+    repo_path = tmp_path / "sample-repo"
+    repo_path.mkdir()
+
+    command = _prepare_command(
+        "python -m pytest tests",
+        str(repo_path),
+        {"python_executable": r"C:\Python313\python.exe"},
+    )
+
+    assert command[0] == r"C:\Python313\python.exe"

--- a/agent/tests/test_local_agent_smoke.py
+++ b/agent/tests/test_local_agent_smoke.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 
 from agent.agent import run_agent
-from agent.executors.pytest_executor import _prepare_command
+from agent.executors.pytest_executor import _prepare_command, _repo_python_candidates
 
 
 def _write_sample_repo(repo_path: Path) -> None:
@@ -116,7 +116,7 @@ artifacts:
 
 def test_python_command_prefers_test_repo_virtualenv(tmp_path):
     repo_path = tmp_path / "sample-repo"
-    python_path = repo_path / ".venv" / "Scripts" / "python.exe"
+    python_path = _repo_python_candidates(str(repo_path))[0]
     python_path.parent.mkdir(parents=True)
     python_path.write_text("", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
Update the Local Agent pytest executor so test repositories own their Python runtime instead of always using the Agent interpreter.

## Proposed Changes
- Resolve python/python3 commands from task parameters, METEORTEST_TEST_PYTHON, or the test repository .venv/venv before falling back to the original command.
- Add regression coverage for repository virtualenv selection and per-task Python overrides.
- Update Agent and bilingual README documentation with the runtime resolution order.

## Test Plan
- agent\.venv\Scripts\python.exe -m pytest agent\tests -q -p no:cacheprovider
- agent\.venv\Scripts\python.exe -m compileall agent\executors agent\services agent\tests

Closes #31