### PR TITLE
[Documentation] Add Web public preview readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,16 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY
 DEEPSEEK_API_KEY optional
 ```
 
-Do not commit `.env.local` or real keys.
+Use `apps/web/.env.local.example` as the committed template. Do not commit `.env.local` or real keys.
+
+For public Web preview work:
+
+- Configure environment variables in the deployment provider, not in committed files.
+- Treat `NEXT_PUBLIC_*` variables as browser-visible.
+- Keep `SUPABASE_SERVICE_ROLE_KEY`, `DEEPSEEK_API_KEY`, local repository paths, and Agent runtime settings server-only or private.
+- Do not expose the Local Agent or local executor endpoints directly to the public internet.
+- Connected execution must use a private Agent polling the backend with scoped credentials.
+- Update README files and `PROGRESS.md` in the same PR when deployment behavior or boundaries change.
 
 ### Agent
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -74,6 +74,8 @@
 
 - [x] 侧栏支持从设置读取自定义平台名称
 - [x] 设置页主题选择写入本地设置并全站生效
+- [x] Phase 11 公网 Web 预览准备：补齐 `.env.local.example`，明确部署环境变量、密钥边界和 Local Agent 不直接公网暴露
+- [ ] Phase 12 Public Connected Demo：基于独立预览后端和私有 Agent 打通可操作 Demo
 - [ ] 参考 `junchen-meteor` 的内容配置方式，建设 `zh-CN` / `en` 多语言文案层
 - [ ] 导航、设置、AI 模板、空状态、表单提示和页面标题接入多语言
 - [ ] README / DESIGN / PROGRESS 保持中英文文档同步

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ DEEPSEEK_API_KEY=your-deepseek-api-key
 
 `DEEPSEEK_API_KEY` is optional. Without it, the AI assistant is unavailable, but projects, tasks, reports, and executor pages can still be developed and tested.
 
+For public Web previews, configure these values in the deployment provider's protected environment settings instead of committing `.env.local`. Keep `SUPABASE_SERVICE_ROLE_KEY`, `DEEPSEEK_API_KEY`, local repository paths, and Local Agent runtime settings server-only or private. A public preview should expose the Web console first; connected execution by a private Local Agent is a separate rollout step.
+
 ### 4. Start the Web console
 
 ```bash
@@ -347,6 +349,8 @@ The Agent will:
 - Write back tasks, reports, and AI analysis records.
 
 The Web executor page also shows Local Agent status and provides a launch entry point. The Settings page can control whether the Agent starts automatically when the executor page is opened.
+
+Do not expose the Local Agent directly on the public internet. For public Web access, the Agent should run privately and poll the platform backend with scoped credentials.
 
 ## Recommended Validation Flow
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,6 +230,8 @@ DEEPSEEK_API_KEY=your-deepseek-api-key
 
 `DEEPSEEK_API_KEY` 是可选项。没有它时，AI 助手不可用，但项目、任务、报告和执行器页面仍可开发和调试。
 
+如果要部署公网 Web 预览，把这些值配置到部署平台的受保护环境变量中，不要提交 `.env.local`。`SUPABASE_SERVICE_ROLE_KEY`、`DEEPSEEK_API_KEY`、本地仓库路径和 Local Agent 运行配置必须保持服务端或本机私有。公网预览应先开放 Web 控制台；由私有 Local Agent 执行真实任务属于后续接入步骤。
+
 ### 4. 启动 Web 控制台
 
 ```bash
@@ -347,6 +349,8 @@ Agent 会：
 - 写回 tasks、reports 和 ai_analyses。
 
 Web 执行器页面也会展示 Local Agent 状态，并提供启动入口。设置页可以控制打开执行器页面时是否自动启动 Agent。
+
+不要把 Local Agent 直接暴露到公网。需要公网访问 Web 时，Agent 应在私有机器或可信 runner 上运行，并通过受控凭据轮询平台后端。
 
 ## 推荐验证流程
 

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,18 @@
+# MeteorTest Web local development
+#
+# Browser-visible Supabase client settings. These values are safe to expose only
+# if the Supabase project has proper Row Level Security policies.
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Server-only settings. Do not prefix these with NEXT_PUBLIC_.
+# Leave empty when you only need the read-only Web preview without AI analysis.
+DEEPSEEK_API_KEY=
+
+# Optional server-side Supabase key for admin/server routes.
+# Never expose this value to the browser or commit a real key.
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Local Agent settings are intentionally not part of the public preview config.
+# Configure the Agent separately in agent/config.yaml and local environment
+# variables when you run private execution from your own machine.

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,6 +6,7 @@ Next.js console for MeteorTest. It owns the dashboard, project center, task cent
 
 ```bash
 npm ci
+cp .env.local.example .env.local
 npm run dev
 ```
 
@@ -26,7 +27,22 @@ DEEPSEEK_API_KEY
 SUPABASE_SERVICE_ROLE_KEY
 ```
 
-Do not commit `.env.local`.
+`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are browser-visible client settings. Keep `DEEPSEEK_API_KEY` and `SUPABASE_SERVICE_ROLE_KEY` server-only; never add the `NEXT_PUBLIC_` prefix to them.
+
+Do not commit `.env.local` or real keys.
+
+## Public Preview Boundary
+
+The Web console can be deployed as a public preview when its provider receives environment variables through protected deployment settings, for example Vercel, Netlify, Cloudflare Pages, or GitHub Actions secrets.
+
+Public preview is for viewing and validating the Web console surface first:
+
+- It may connect to a dedicated preview Supabase project.
+- It must not expose `SUPABASE_SERVICE_ROLE_KEY`, `DEEPSEEK_API_KEY`, local file paths, or local Agent runtime settings to the browser.
+- It must not directly expose the Local Agent or a machine-local executor on the public internet.
+- Real connected execution remains a separate step: the private Local Agent should poll the platform backend from the user's machine or trusted runner.
+
+For a safe preview setup, start with empty data or demo data, then enable connected execution only after the backend policies, storage access, and Agent trust boundary are reviewed.
 
 ## UI Direction
 


### PR DESCRIPTION
## Summary
Prepare MeteorTest Web for a safe public preview setup without exposing local execution or private credentials.

## Proposed Changes
- Add a committed apps/web/.env.local.example template for local and preview setup.
- Document deployment provider environment variable handling for public Web previews.
- Clarify that SUPABASE_SERVICE_ROLE_KEY, DEEPSEEK_API_KEY, local paths, and Local Agent runtime settings must stay server-only or private.
- Mark Phase 11 readiness in PROGRESS and keep the connected public demo as the next phase.

## Test Plan
- npm run lint
- npm run build
- agent/.venv/Scripts/python.exe -m compileall -q agent/executors agent/reporters agent/services agent/tests
- agent/.venv/Scripts/python.exe -m pytest agent/tests -q --basetemp pytest-cache-files-agent-run2

## Notes
The Web build still reports an existing Turbopack tracing warning from app/api/agent/status/route.ts importing next.config.ts. This PR does not touch that path.

Closes #37