### PR TITLE
[Documentation] Document Web preview deployment runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,8 @@ For public Web preview work:
 - Do not expose the Local Agent or local executor endpoints directly to the public internet.
 - Connected execution must use a private Agent polling the backend with scoped credentials.
 - Update README files and `PROGRESS.md` in the same PR when deployment behavior or boundaries change.
+- Follow the public preview deployment runbook in `apps/web/README.md` before opening a live public URL. Do not skip directly to connected execution.
+- For Vercel deployment, follow `docs/vercel-public-preview.md` and `docs/vercel-public-preview.zh-CN.md`.
 
 ### Agent
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -75,6 +75,8 @@
 - [x] 侧栏支持从设置读取自定义平台名称
 - [x] 设置页主题选择写入本地设置并全站生效
 - [x] Phase 11 公网 Web 预览准备：补齐 `.env.local.example`，明确部署环境变量、密钥边界和 Local Agent 不直接公网暴露
+- [x] Phase 11 Vercel 部署 runbook：记录账号操作、环境变量、Supabase 预览环境、Codex 可协助范围和人工必须提供内容
+- [ ] Phase 11 公网 Web 预览部署：按 `apps/web/README.md` runbook 选择托管平台、配置独立预览 Supabase、设置部署平台环境变量并发布公网 URL
 - [ ] Phase 12 Public Connected Demo：基于独立预览后端和私有 Agent 打通可操作 Demo
 - [ ] 参考 `junchen-meteor` 的内容配置方式，建设 `zh-CN` / `en` 多语言文案层
 - [ ] 导航、设置、AI 模板、空状态、表单提示和页面标题接入多语言

--- a/README.md
+++ b/README.md
@@ -352,6 +352,28 @@ The Web executor page also shows Local Agent status and provides a launch entry 
 
 Do not expose the Local Agent directly on the public internet. For public Web access, the Agent should run privately and poll the platform backend with scoped credentials.
 
+## Public Web Preview Deployment
+
+MeteorTest Web needs an application host that can run Next.js server routes. GitHub Pages is not enough for this app because routes such as `/api/tasks`, `/api/projects`, and `/api/ai/chat` require a server runtime.
+
+Follow this order:
+
+1. Choose a host such as Vercel, Netlify, Cloudflare Workers/Pages with a server runtime, or a controlled server.
+2. Create an isolated preview Supabase project or schema and run the migrations in `supabase/migrations/`.
+3. Configure provider-managed environment variables for `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and optional `DEEPSEEK_API_KEY`.
+4. Keep Local Agent paths and machine-local runtime variables out of the public Web deployment.
+5. Deploy `apps/web` with Node.js 22, `npm ci`, and `npm run build`.
+6. Smoke-check all public routes and confirm no secrets, local paths, or Local Agent endpoints are exposed.
+7. Treat private Agent polling and public connected execution as later steps after safety and access controls are reviewed.
+
+The detailed runbook lives in `apps/web/README.md`.
+
+For Vercel-specific deployment steps, see:
+
+```text
+docs/vercel-public-preview.md
+```
+
 ## Recommended Validation Flow
 
 1. Run Supabase migrations.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -352,6 +352,28 @@ Web 执行器页面也会展示 Local Agent 状态，并提供启动入口。设
 
 不要把 Local Agent 直接暴露到公网。需要公网访问 Web 时，Agent 应在私有机器或可信 runner 上运行，并通过受控凭据轮询平台后端。
 
+## 公网 Web 预览部署
+
+MeteorTest Web 需要能运行 Next.js 服务端路由的应用托管平台。GitHub Pages 不适合这个应用，因为 `/api/tasks`、`/api/projects`、`/api/ai/chat` 等路由需要服务端运行时。
+
+按以下顺序操作：
+
+1. 选择 Vercel、Netlify、带服务端运行时的 Cloudflare Workers/Pages，或受控服务器。
+2. 创建隔离的预览 Supabase 项目或 schema，并执行 `supabase/migrations/` 里的迁移。
+3. 在部署平台配置受保护环境变量：`NEXT_PUBLIC_SUPABASE_URL`、`NEXT_PUBLIC_SUPABASE_ANON_KEY`、`SUPABASE_SERVICE_ROLE_KEY`，以及可选的 `DEEPSEEK_API_KEY`。
+4. 不要把 Local Agent 路径和本机运行时变量放进公网 Web 部署。
+5. 使用 Node.js 22、`npm ci`、`npm run build` 部署 `apps/web`。
+6. 对公网路由做 smoke check，确认没有暴露密钥、本机路径或 Local Agent 端点。
+7. 私有 Agent 轮询和公网联网执行属于后续步骤，必须先完成安全和访问控制评审。
+
+详细 runbook 见 `apps/web/README.md`。
+
+Vercel 专项部署步骤见：
+
+```text
+docs/vercel-public-preview.zh-CN.md
+```
+
 ## 推荐验证流程
 
 1. 执行 Supabase 迁移。

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -44,6 +44,38 @@ Public preview is for viewing and validating the Web console surface first:
 
 For a safe preview setup, start with empty data or demo data, then enable connected execution only after the backend policies, storage access, and Agent trust boundary are reviewed.
 
+## Public Preview Deployment Runbook
+
+Use this order when opening MeteorTest Web on the public internet:
+
+1. Choose an application host that supports Next.js server routes, such as Vercel, Netlify, Cloudflare Workers/Pages with a server runtime, or a controlled server. Do not use GitHub Pages for MeteorTest Web because it cannot run `/api/*` routes.
+2. Create a dedicated preview Supabase project or a clearly isolated preview schema. Run the migrations from `supabase/migrations/` and use demo or empty data first.
+3. Configure deployment-provider environment variables:
+
+   ```text
+   NEXT_PUBLIC_SUPABASE_URL
+   NEXT_PUBLIC_SUPABASE_ANON_KEY
+   SUPABASE_SERVICE_ROLE_KEY
+   DEEPSEEK_API_KEY optional
+   ```
+
+4. Keep `METEORTEST_REPO_ROOT`, `METEORTEST_AGENT_PYTHON`, `METEORTEST_AGENT_INTERVAL`, local repository paths, and local Agent config out of the public Web deployment unless a reviewed execution-safety design exists.
+5. Deploy `apps/web` with Node.js 22, `npm ci`, and `npm run build`.
+6. Smoke-check the public URL:
+
+   - Dashboard loads.
+   - Projects, tasks, reports, builds, executors, and settings routes load.
+   - API routes do not print secrets or local machine paths.
+   - Executor controls do not expose a public Local Agent endpoint.
+   - AI assistant returns a clear unavailable state if `DEEPSEEK_API_KEY` is not configured.
+
+7. Only after the Web preview is stable, decide whether a private Local Agent should poll the preview backend with scoped credentials. Do not expose a machine-local Agent endpoint directly to public traffic.
+
+For a detailed Vercel-specific walkthrough, see:
+
+- `docs/vercel-public-preview.md`
+- `docs/vercel-public-preview.zh-CN.md`
+
 ## UI Direction
 
 The console should be visually consistent across pages. Use shared CSS variables and semantic classes from `app/globals.css` instead of hard-coded page colors.

--- a/docs/vercel-public-preview.md
+++ b/docs/vercel-public-preview.md
@@ -1,0 +1,135 @@
+# Vercel Public Preview Deployment
+
+This runbook describes how to deploy MeteorTest Web to Vercel as a public preview. Follow it before adding any public MeteorTest Web URL to README files, the personal website, or project documentation.
+
+## Deployment Goal
+
+Deploy the Web console only:
+
+- Public visitors can open the MeteorTest Web UI.
+- The deployment uses an isolated preview Supabase project or schema.
+- Secrets live in Vercel Project Settings, not in Git.
+- Local Agent execution stays private.
+- Public connected execution remains out of scope until authentication, data isolation, rate limits, and executor safety are designed.
+
+## What The User Must Provide Manually
+
+The project owner must do these steps because they involve account ownership, browser login, or secrets:
+
+1. Log in to Vercel with the intended GitHub account.
+2. Authorize Vercel to access `JunchenMeteor/MeteorTest`.
+3. Create or select a preview Supabase project.
+4. Run the Supabase migrations against that preview project.
+5. Copy the real Supabase URL, anon key, and service-role key from Supabase.
+6. Decide whether `DEEPSEEK_API_KEY` should be enabled for the preview.
+7. Add environment variables in Vercel Project Settings.
+8. Click Deploy or Redeploy in Vercel.
+9. Share the public preview URL or deployment error logs for follow-up checks.
+
+Do not paste real service-role keys, API keys, or private project URLs into chat, issues, PR bodies, README files, screenshots, or committed files.
+
+## What Codex Can Help With
+
+Codex can do these steps from the repository:
+
+1. Verify the Web app builds locally with `npm run lint` and `npm run build`.
+2. Review which environment variables the code reads.
+3. Update README, AGENTS, PROGRESS, and runbooks.
+4. Add safety checks or clearer unavailable states if the public preview exposes confusing controls.
+5. Review Vercel build logs if the user provides the non-secret error output.
+6. Debug public URL behavior after deployment.
+7. Prepare PRs for fixes.
+
+Codex should not configure production secrets or log in to the user's Vercel, Supabase, or AI provider accounts.
+
+## Required Vercel Project Settings
+
+Import settings:
+
+```text
+Git repository: JunchenMeteor/MeteorTest
+Framework preset: Next.js
+Root Directory: apps/web
+Install Command: npm ci
+Build Command: npm run build
+Output Directory: default / leave empty
+Node.js version: 22
+```
+
+Environment variables:
+
+```text
+NEXT_PUBLIC_SUPABASE_URL=https://your-preview-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-preview-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-preview-service-role-key
+DEEPSEEK_API_KEY=optional
+```
+
+Use Vercel Project Settings for these values. Do not commit `.env.local`.
+
+Important boundaries:
+
+- `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are browser-visible.
+- `SUPABASE_SERVICE_ROLE_KEY` and `DEEPSEEK_API_KEY` are server-only.
+- Never add the `NEXT_PUBLIC_` prefix to service-role or AI provider keys.
+- Do not configure `METEORTEST_REPO_ROOT`, `METEORTEST_AGENT_PYTHON`, `METEORTEST_AGENT_INTERVAL`, local repository paths, or local Agent config in the public deployment unless an execution-safety design exists.
+
+## Supabase Preview Setup
+
+Use a dedicated preview project or a clearly isolated preview schema.
+
+Run migrations in order:
+
+```text
+supabase/migrations/001_init.sql
+supabase/migrations/002_app_builds.sql
+supabase/migrations/003_constraints.sql
+```
+
+For the first public preview, prefer empty data or demo data. Do not connect real device records, private app builds, internal URLs, real test accounts, or production report storage.
+
+## Vercel Dashboard Flow
+
+1. Open Vercel.
+2. Select the correct personal account or team.
+3. Choose `Add New...` then `Project`.
+4. Import `JunchenMeteor/MeteorTest`.
+5. In project configuration, set `Root Directory` to `apps/web`.
+6. Confirm the framework is `Next.js`.
+7. Set the install command to `npm ci`.
+8. Set the build command to `npm run build`.
+9. Set Node.js version to `22` in Project Settings if the import page does not show it.
+10. Open Environment Variables and add the required variables for Preview and Production as appropriate.
+11. Deploy.
+
+If an environment variable changes later, redeploy. Vercel environment variable changes do not modify already-created deployments.
+
+## First Smoke Check After Deployment
+
+Open the deployment URL and check:
+
+1. `/` loads.
+2. `/projects` loads.
+3. `/tasks` loads.
+4. `/reports` loads.
+5. `/builds` loads.
+6. `/executors` loads without exposing local machine paths or a public Local Agent endpoint.
+7. `/settings` loads.
+8. API calls do not print secrets, service-role keys, local paths, or stack traces containing private values.
+9. AI assistant shows a clear unavailable state if `DEEPSEEK_API_KEY` is not configured.
+
+If a page fails, capture the Vercel deployment log lines and browser console/network errors, with secrets redacted.
+
+## After The Preview URL Works
+
+Only after the URL is verified:
+
+1. Add the public MeteorTest Web preview link to the personal website.
+2. Update `README.md`, `README.zh-CN.md`, `PROGRESS.md`, and `AGENTS.md`.
+3. Keep Phase 12 public connected execution deferred unless the safety design is complete.
+
+## References
+
+- Vercel project settings: https://vercel.com/docs/project-configuration/project-settings
+- Vercel environment variables: https://vercel.com/docs/projects/environment-variables
+- Next.js environment variables: https://nextjs.org/docs/pages/guides/environment-variables

--- a/docs/vercel-public-preview.zh-CN.md
+++ b/docs/vercel-public-preview.zh-CN.md
@@ -1,0 +1,135 @@
+# Vercel 公网预览部署流程
+
+这份 runbook 用于把 MeteorTest Web 部署到 Vercel，作为公网预览。只有按这里完成并验证后，才应该把 MeteorTest Web 的公网地址写入 README、个人官网或项目文档。
+
+## 部署目标
+
+这次只部署 Web 控制台：
+
+- 访问者可以打开 MeteorTest Web UI。
+- 部署连接隔离的预览 Supabase 项目或 schema。
+- 密钥放在 Vercel Project Settings，不进入 Git。
+- Local Agent 执行保持私有。
+- 公网联网执行仍然不在本阶段范围内，必须等认证、数据隔离、限流和执行器安全设计完成后再做。
+
+## 你必须手动提供或操作的部分
+
+以下步骤涉及账号归属、浏览器登录或真实密钥，必须由项目所有者手动完成：
+
+1. 用目标 GitHub 账号登录 Vercel。
+2. 授权 Vercel 访问 `JunchenMeteor/MeteorTest`。
+3. 创建或选择一个预览 Supabase 项目。
+4. 在这个预览项目中执行 Supabase migrations。
+5. 从 Supabase 复制真实的 Supabase URL、anon key 和 service-role key。
+6. 决定是否给预览环境启用 `DEEPSEEK_API_KEY`。
+7. 在 Vercel Project Settings 中添加环境变量。
+8. 在 Vercel 中点击 Deploy 或 Redeploy。
+9. 把公网预览 URL 或部署错误日志发回来，供后续排查。
+
+不要把真实 service-role key、API key 或私有项目 URL 粘贴到聊天、issue、PR 描述、README、截图或提交文件中。
+
+## Codex 可以帮你做的部分
+
+Codex 可以在仓库侧完成这些事：
+
+1. 用 `npm run lint` 和 `npm run build` 验证 Web 应用。
+2. 检查代码实际读取了哪些环境变量。
+3. 更新 README、AGENTS、PROGRESS 和 runbook。
+4. 如果公网预览暴露了令人困惑的入口，补充安全提示或不可用状态。
+5. 在你提供脱敏错误日志后，分析 Vercel build 失败原因。
+6. 部署后帮你检查公网 URL 的页面行为。
+7. 准备修复 PR。
+
+Codex 不应该替你配置生产密钥，也不应该登录你的 Vercel、Supabase 或 AI 服务账号。
+
+## Vercel 项目配置
+
+导入配置：
+
+```text
+Git repository: JunchenMeteor/MeteorTest
+Framework preset: Next.js
+Root Directory: apps/web
+Install Command: npm ci
+Build Command: npm run build
+Output Directory: 默认 / 留空
+Node.js version: 22
+```
+
+环境变量：
+
+```text
+NEXT_PUBLIC_SUPABASE_URL=https://your-preview-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-preview-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-preview-service-role-key
+DEEPSEEK_API_KEY=可选
+```
+
+这些值要配置在 Vercel Project Settings 中，不要提交 `.env.local`。
+
+重要边界：
+
+- `NEXT_PUBLIC_SUPABASE_URL` 和 `NEXT_PUBLIC_SUPABASE_ANON_KEY` 会暴露到浏览器端。
+- `SUPABASE_SERVICE_ROLE_KEY` 和 `DEEPSEEK_API_KEY` 只能服务端使用。
+- 不要给 service-role key 或 AI 服务 key 加 `NEXT_PUBLIC_` 前缀。
+- 不要在公网部署中配置 `METEORTEST_REPO_ROOT`、`METEORTEST_AGENT_PYTHON`、`METEORTEST_AGENT_INTERVAL`、本地仓库路径或本机 Agent 配置，除非已经完成执行安全设计。
+
+## Supabase 预览环境
+
+使用专门的预览 Supabase 项目，或清晰隔离的预览 schema。
+
+按顺序执行迁移：
+
+```text
+supabase/migrations/001_init.sql
+supabase/migrations/002_app_builds.sql
+supabase/migrations/003_constraints.sql
+```
+
+第一次公网预览优先使用空数据或 demo 数据。不要接入真实设备记录、私有 app 构建、内部 URL、真实测试账号或生产报告存储。
+
+## Vercel 页面操作流程
+
+1. 打开 Vercel。
+2. 选择正确的个人账号或 team。
+3. 选择 `Add New...`，再选择 `Project`。
+4. 导入 `JunchenMeteor/MeteorTest`。
+5. 在项目配置中，把 `Root Directory` 设置为 `apps/web`。
+6. 确认 framework 是 `Next.js`。
+7. 把 install command 设置为 `npm ci`。
+8. 把 build command 设置为 `npm run build`。
+9. 如果导入页面没有显示 Node.js 版本，在 Project Settings 中设置 Node.js version 为 `22`。
+10. 打开 Environment Variables，为需要的环境添加上述变量。
+11. 点击 Deploy。
+
+如果后续修改了环境变量，需要重新部署。Vercel 的环境变量变更不会影响已经创建的旧部署。
+
+## 部署后的第一次 smoke check
+
+打开部署 URL，检查：
+
+1. `/` 可以加载。
+2. `/projects` 可以加载。
+3. `/tasks` 可以加载。
+4. `/reports` 可以加载。
+5. `/builds` 可以加载。
+6. `/executors` 可以加载，并且没有暴露本机路径或公网 Local Agent 端点。
+7. `/settings` 可以加载。
+8. API 调用不会输出密钥、service-role key、本机路径或包含私密值的堆栈。
+9. 如果没有配置 `DEEPSEEK_API_KEY`，AI assistant 应显示清晰的不可用状态。
+
+如果页面失败，保留 Vercel deployment log、浏览器 console 和 network 错误，但要先脱敏密钥。
+
+## 预览 URL 可用之后
+
+只有 URL 验证通过后，再做这些事：
+
+1. 把 MeteorTest Web 公网预览链接加到个人官网。
+2. 更新 `README.md`、`README.zh-CN.md`、`PROGRESS.md` 和 `AGENTS.md`。
+3. Phase 12 公网联网执行继续保持延期，除非安全设计已经完成。
+
+## 参考资料
+
+- Vercel project settings: https://vercel.com/docs/project-configuration/project-settings
+- Vercel environment variables: https://vercel.com/docs/projects/environment-variables
+- Next.js environment variables: https://nextjs.org/docs/pages/guides/environment-variables


### PR DESCRIPTION
## Summary
Record the ordered deployment runbook for opening MeteorTest Web as a public preview, including a Vercel-specific walkthrough.

## Proposed Changes
- Add a public preview deployment runbook to apps/web/README.md.
- Add detailed English and Chinese Vercel runbooks under docs/.
- Document what the user must provide manually: Vercel login, GitHub authorization, preview Supabase, real env vars, Deploy/Redeploy, and sanitized logs.
- Document what Codex can help with: local validation, env-var review, docs, unavailable states, log analysis, URL debugging, and PR fixes.
- Document why GitHub Pages is not sufficient for MeteorTest Web because Next.js API routes need a server runtime.
- Mirror the deployment order in the root English and Chinese READMEs.
- Update AGENTS and PROGRESS so future work follows the runbook before opening a live public URL.

## Test Plan
- npm run lint
- npm run build

## Notes
The Web build still reports an existing Turbopack tracing warning from app/api/agent/status/route.ts importing next.config.ts. This PR does not touch that path.

Closes #39