### PR TITLE
[Feature] Add safe preview seed data

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -56,14 +56,14 @@
 
 ### Preview Data Initialization
 
-- [ ] 增加 `supabase/seed-preview.sql` 或脚本化 seed 流程
-- [ ] Demo project：`iOS-Automation-Framework`
-- [ ] Demo suite：`api_smoke`
-- [ ] Demo tasks：至少覆盖 queued、succeeded、failed
-- [ ] Demo report：包含 pytest summary、日志链接占位、AI 分析摘要
-- [ ] Demo executor：`local-agent-demo`，状态为 offline/disabled，明确不是公网 Agent
-- [ ] Demo build：示例 app build 元数据，不包含真实包、内部 URL、账号或设备信息
-- [ ] Runbook 记录如何在新的 preview Supabase 中初始化 demo 数据
+- [x] 增加 `supabase/seed-preview.sql` 或脚本化 seed 流程
+- [x] Demo project：`iOS-Automation-Framework`
+- [x] Demo suite：`api_smoke`
+- [x] Demo tasks：至少覆盖 queued、succeeded、failed
+- [x] Demo report：包含 pytest summary、日志链接占位、AI 分析摘要
+- [x] Demo executor：`local-agent-demo`，状态为 offline/disabled，明确不是公网 Agent
+- [x] Demo build：示例 app build 元数据，不包含真实包、内部 URL、账号或设备信息
+- [x] Runbook 记录如何在新的 preview Supabase 中初始化 demo 数据
 
 ### Task And Report Experience
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -92,6 +92,14 @@ For a detailed Vercel-specific walkthrough, see:
 - `docs/vercel-public-preview.md`
 - `docs/vercel-public-preview.zh-CN.md`
 
+Preview seed data:
+
+```text
+supabase/seed-preview.sql
+```
+
+Run it after the migrations when you want the public preview to show safe demo projects, suites, tasks, reports, an offline demo executor, and AI analysis examples. The seed uses placeholder URLs and synthetic execution data only.
+
 ## UI Direction
 
 The console should be visually consistent across pages. Use shared CSS variables and semantic classes from `app/globals.css` instead of hard-coded page colors.

--- a/docs/vercel-public-preview.md
+++ b/docs/vercel-public-preview.md
@@ -92,6 +92,14 @@ supabase/migrations/003_constraints.sql
 
 For the first public preview, prefer empty data or demo data. Do not connect real device records, private app builds, internal URLs, real test accounts, or production report storage.
 
+To seed public-safe demo data after migrations, run:
+
+```text
+supabase/seed-preview.sql
+```
+
+The seed creates a demo `iOS-Automation-Framework` project, `api_smoke` suite, placeholder build metadata, an offline `local-agent-demo` executor, queued/succeeded/failed tasks, report summaries, and a synthetic AI analysis row. It is intended for preview surfaces only and must not be edited to include private endpoints, local paths, credentials, real devices, or production artifacts.
+
 ## Vercel Dashboard Flow
 
 1. Open Vercel.
@@ -136,7 +144,7 @@ Then continue hardening in this order:
 
 1. Public preview mode: make Agent startup impossible in public deployments and document the unavailable state.
 2. Access protection: enable Vercel Deployment Protection, Vercel Password, or an equivalent guard before long-lived public use.
-3. Preview data: seed safe demo projects, suites, tasks, reports, executors, and builds.
+3. Preview data: run `supabase/seed-preview.sql` to seed safe demo projects, suites, tasks, reports, executors, and builds.
 4. Task/report experience: make failed-task analysis readable through status, logs, failure category, AI analysis, and next actions.
 5. Private Agent loop: connect a private Local Agent to the preview backend only after the above is stable.
 

--- a/docs/vercel-public-preview.zh-CN.md
+++ b/docs/vercel-public-preview.zh-CN.md
@@ -92,6 +92,14 @@ supabase/migrations/003_constraints.sql
 
 第一次公网预览优先使用空数据或 demo 数据。不要接入真实设备记录、私有 app 构建、内部 URL、真实测试账号或生产报告存储。
 
+如果需要初始化公开安全的 demo 数据，在迁移后执行：
+
+```text
+supabase/seed-preview.sql
+```
+
+这个 seed 会创建 demo `iOS-Automation-Framework` 项目、`api_smoke` suite、占位构建元数据、离线的 `local-agent-demo` 执行器、queued/succeeded/failed 任务、报告摘要和一条合成 AI 分析记录。它只用于预览页面，不要改成包含私有端点、本机路径、凭据、真实设备或生产产物的数据。
+
 ## Vercel 页面操作流程
 
 1. 打开 Vercel。
@@ -136,7 +144,7 @@ supabase/migrations/003_constraints.sql
 
 1. 公网预览模式：确保公网部署不可能启动本机 Agent，并记录不可用状态。
 2. 访问保护：长期公开前启用 Vercel Deployment Protection、Vercel Password 或等价保护。
-3. 预览数据：初始化安全 demo 项目、suite、任务、报告、执行器和构建数据。
+3. 预览数据：执行 `supabase/seed-preview.sql` 初始化安全 demo 项目、suite、任务、报告、执行器和构建数据。
 4. 任务/报告体验：通过状态、日志、失败分类、AI 分析和下一步建议，让 failed task 可读。
 5. 私有 Agent 闭环：上述稳定后，再让私有 Local Agent 连接 preview backend。
 

--- a/supabase/seed-preview.sql
+++ b/supabase/seed-preview.sql
@@ -1,0 +1,250 @@
+-- Safe demo dataset for MeteorTest public preview environments.
+--
+-- Run after:
+--   supabase/migrations/001_init.sql
+--   supabase/migrations/002_app_builds.sql
+--   supabase/migrations/003_constraints.sql
+--
+-- This seed intentionally uses public-safe placeholder URLs and synthetic
+-- execution data. Do not replace these values with real device records,
+-- private app builds, internal URLs, test accounts, local paths, or secrets.
+
+begin;
+
+insert into projects (key, name, repo_url, description)
+values (
+  'ios-automation-framework',
+  'iOS-Automation-Framework',
+  'https://github.com/JunchenMeteor/iOS-Automation-Framework',
+  'Public-safe demo project for MeteorTest preview data. It mirrors the first test-project integration sample without exposing private devices or accounts.'
+)
+on conflict (key) do update set
+  name = excluded.name,
+  repo_url = excluded.repo_url,
+  description = excluded.description;
+
+with demo_project as (
+  select id from projects where key = 'ios-automation-framework'
+)
+insert into test_suites (project_id, suite_key, name, type, command, requires)
+select
+  demo_project.id,
+  'api_smoke',
+  'API Smoke',
+  'api',
+  'python -m pytest API_Automation/cases -m smoke --alluredir=Reports/platform/preview-smoke/allure-results',
+  array['python', 'pytest', 'local_mock_api']
+from demo_project
+on conflict (project_id, suite_key) do update set
+  name = excluded.name,
+  type = excluded.type,
+  command = excluded.command,
+  requires = excluded.requires;
+
+with demo_project as (
+  select id from projects where key = 'ios-automation-framework'
+)
+insert into app_builds (
+  project_id,
+  platform,
+  version,
+  build_number,
+  artifact_url,
+  bundle_id,
+  package_name,
+  git_commit
+)
+select
+  demo_project.id,
+  'ios',
+  'preview-1.0.0',
+  '100',
+  'https://example.com/meteortest-preview/demo-app-build.ipa',
+  'com.jcmeteor.preview',
+  null,
+  'preview-demo'
+from demo_project
+where not exists (
+  select 1
+  from app_builds
+  where project_id = demo_project.id
+    and platform = 'ios'
+    and version = 'preview-1.0.0'
+    and build_number = '100'
+);
+
+insert into executors (name, type, status, capabilities, last_heartbeat_at)
+values (
+  'local-agent-demo',
+  'local_mac',
+  'offline',
+  array['api', 'pytest', 'preview-only'],
+  now() - interval '2 hours'
+)
+on conflict (name) do update set
+  type = excluded.type,
+  status = excluded.status,
+  capabilities = excluded.capabilities,
+  last_heartbeat_at = excluded.last_heartbeat_at;
+
+with refs as (
+  select
+    projects.id as project_id,
+    test_suites.id as suite_id,
+    executors.id as executor_id,
+    (
+      select app_builds.id
+      from app_builds
+      where app_builds.project_id = projects.id
+        and app_builds.platform = 'ios'
+        and app_builds.version = 'preview-1.0.0'
+        and app_builds.build_number = '100'
+      order by app_builds.created_at desc
+      limit 1
+    ) as app_build_id
+  from projects
+  join test_suites on test_suites.project_id = projects.id
+  join executors on executors.name = 'local-agent-demo'
+  where projects.key = 'ios-automation-framework'
+    and test_suites.suite_key = 'api_smoke'
+),
+seed_tasks as (
+  select *
+  from refs
+  cross join lateral (
+    values
+      (
+        'preview-api-smoke-queued',
+        'queued',
+        null::timestamptz,
+        null::timestamptz,
+        null::uuid,
+        jsonb_build_object(
+          'preview_task_key', 'preview-api-smoke-queued',
+          'display_name', 'Preview queued API smoke',
+          'source', 'seed-preview',
+          'safe_demo', true,
+          'notes', 'Queued demo task for public preview surfaces.'
+        )
+      ),
+      (
+        'preview-api-smoke-succeeded',
+        'succeeded',
+        now() - interval '90 minutes',
+        now() - interval '86 minutes',
+        null::uuid,
+        jsonb_build_object(
+          'preview_task_key', 'preview-api-smoke-succeeded',
+          'display_name', 'Preview succeeded API smoke',
+          'source', 'seed-preview',
+          'safe_demo', true,
+          'pytest', jsonb_build_object('passed', 6, 'deselected', 16, 'exit_code', 0)
+        )
+      ),
+      (
+        'preview-api-smoke-failed',
+        'failed',
+        now() - interval '45 minutes',
+        now() - interval '41 minutes',
+        executor_id,
+        jsonb_build_object(
+          'preview_task_key', 'preview-api-smoke-failed',
+          'display_name', 'Preview failed API smoke',
+          'source', 'seed-preview',
+          'safe_demo', true,
+          'failure_category', 'environment',
+          'pytest', jsonb_build_object('passed', 5, 'failed', 1, 'deselected', 16, 'exit_code', 1)
+        )
+      )
+  ) as task_values(task_key, status, started_at, finished_at, executor_for_task, parameters)
+),
+inserted_tasks as (
+  insert into tasks (
+    project_id,
+    suite_id,
+    app_build_id,
+    environment,
+    status,
+    executor_id,
+    parameters,
+    created_by,
+    created_at,
+    started_at,
+    finished_at
+  )
+  select
+    project_id,
+    suite_id,
+    app_build_id,
+    'preview',
+    status,
+    executor_for_task,
+    parameters,
+    'preview-seed',
+    now() - interval '2 hours',
+    started_at,
+    finished_at
+  from seed_tasks
+  where not exists (
+    select 1
+    from tasks existing
+    where existing.parameters ->> 'preview_task_key' = seed_tasks.task_key
+  )
+  returning id, parameters
+)
+insert into reports (task_id, log_url, allure_url, screenshots, summary)
+select
+  inserted_tasks.id,
+  case inserted_tasks.parameters ->> 'preview_task_key'
+    when 'preview-api-smoke-succeeded' then 'https://example.com/meteortest-preview/logs/api-smoke-succeeded.log'
+    when 'preview-api-smoke-failed' then 'https://example.com/meteortest-preview/logs/api-smoke-failed.log'
+    else null
+  end,
+  case inserted_tasks.parameters ->> 'preview_task_key'
+    when 'preview-api-smoke-succeeded' then 'https://example.com/meteortest-preview/allure/api-smoke-succeeded/'
+    when 'preview-api-smoke-failed' then 'https://example.com/meteortest-preview/allure/api-smoke-failed/'
+    else null
+  end,
+  array[]::text[],
+  case inserted_tasks.parameters ->> 'preview_task_key'
+    when 'preview-api-smoke-succeeded' then 'Preview API smoke completed successfully: 6 passed, 16 deselected, exit code 0.'
+    when 'preview-api-smoke-failed' then 'Preview API smoke failed in a synthetic environment-check case: 5 passed, 1 failed, 16 deselected, exit code 1.'
+    else 'Preview queued task has not produced a report yet.'
+  end
+from inserted_tasks
+where inserted_tasks.parameters ->> 'preview_task_key' in (
+  'preview-api-smoke-succeeded',
+  'preview-api-smoke-failed'
+);
+
+with failed_task as (
+  select id
+  from tasks
+  where parameters ->> 'preview_task_key' = 'preview-api-smoke-failed'
+  limit 1
+)
+insert into ai_analyses (
+  task_id,
+  failure_reason,
+  impact,
+  suggestion,
+  suspected_files,
+  flaky_probability,
+  raw_response
+)
+select
+  failed_task.id,
+  'Synthetic preview failure: the mock API health check returned an unexpected status.',
+  'Preview-only impact. This row demonstrates how MeteorTest presents failed-task context without exposing real environments.',
+  'Check API_BASE_URL, mock API startup state, and environment selection before rerunning the smoke suite.',
+  array['API_Automation/cases/test_health.py', 'tools/mock_api/server.py'],
+  0.18,
+  'Preview seed analysis. No real logs, credentials, devices, or private endpoints are included.'
+from failed_task
+where not exists (
+  select 1
+  from ai_analyses existing
+  where existing.task_id = failed_task.id
+);
+
+commit;


### PR DESCRIPTION
## Summary
- add a repeatable public-safe Supabase preview seed dataset
- seed demo project, suite, build, offline executor, queued/succeeded/failed tasks, reports, and synthetic AI analysis
- document how to run the seed after migrations in the Web README and Vercel runbooks
- update PROGRESS to mark preview data initialization complete

## Validation
- git diff --check
- cd apps/web && npm run lint
- cd apps/web && npm run build

Note: local SQL execution was not run because psql is not installed in this environment.

Closes #55