### PR TITLE
[Feature] Add public preview smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Public preview smoke check
+        run: npm run smoke:public-preview
+
   agent:
     name: Agent smoke tests
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ The web console should feel like a restrained operations console, with visual in
 - Interactive controls must use control-specific tokens such as `--control-on-bg`, `--control-on-border`, and `--control-on-thumb`; do not bind switches directly to `--accent` when that creates poor contrast in light themes.
 - UI changes must be implemented together with the locale content they display. When adding or changing labels, headings, empty states, helper text, table headers, buttons, status text, or user-facing fallback messages, update `apps/web/content/i18n.ts` in the same change and consume the value through `getDictionary()` or `useLocale()`.
 - Do not merge UI-only wording changes that bypass the i18n layer. Hard-coded UI text is only acceptable for stable product names, technical identifiers, user data, route names, or third-party names.
+- Web-side automation and validation scripts should use TypeScript (`.ts` or `.mts`) when project tooling allows it. Avoid adding ad hoc `.js` or `.mjs` scripts for Web work unless the file is a framework-required config file or there is a documented runtime constraint.
 
 ## Internationalization Direction
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -45,7 +45,10 @@
 - [x] Executors 页面在 public preview 下显示“公网部署不启动 Local Agent；请在私有机器上单独运行 Agent 并轮询后端”
 - [x] Settings 页面在 public preview 下隐藏或禁用 auto-start Agent 控制，避免误导
 - [x] Vercel runbook 明确不要配置 `METEORTEST_REPO_ROOT`、`METEORTEST_AGENT_PYTHON`、`METEORTEST_AGENT_INTERVAL` 或本机路径
-- [ ] Smoke check 覆盖 `/executors` 和 `/api/agent/status`，确认不暴露本机路径、栈信息、密钥或 Agent 启动入口
+- [x] Smoke check 覆盖 `/executors` 和 `/api/agent/status`，确认不暴露本机路径、栈信息、密钥或 Agent 启动入口
+  - `apps/web/scripts/check-public-preview.mts` 使用 public-preview 环境构建并启动独立 smoke server。
+  - CI 通过 `npm run smoke:public-preview` 验证 `/api/agent/status` 禁用 Agent 控制、`/executors` 服务端渲染 public preview 边界提示，并扫描响应中是否出现本机路径、密钥变量、栈信息或 Agent 启动入口。
+  - smoke 使用 `METEORTEST_SMOKE_NO_SUPABASE=1` 跳过 Supabase 查询；Vercel 真实公网预览已配置 Supabase 密钥时仍可正常展示 preview 数据。
 
 ### Authentication And Access Control
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -64,7 +64,7 @@ Use this order when opening MeteorTest Web on the public internet:
    SUPABASE_SERVICE_ROLE_KEY
    DEEPSEEK_API_KEY optional
    METEORTEST_AGENT_DISABLED=1
-   METEORTEST_PUBLIC_PREVIEW=1 once implemented
+   METEORTEST_PUBLIC_PREVIEW=1
    ```
 
 4. Keep `METEORTEST_REPO_ROOT`, `METEORTEST_AGENT_PYTHON`, `METEORTEST_AGENT_INTERVAL`, local repository paths, and local Agent config out of the public Web deployment unless a reviewed execution-safety design exists.
@@ -78,6 +78,14 @@ Use this order when opening MeteorTest Web on the public internet:
    - AI assistant returns a clear unavailable state if `DEEPSEEK_API_KEY` is not configured.
 
 7. Only after the Web preview is stable, decide whether a private Local Agent should poll the preview backend with scoped credentials. Do not expose a machine-local Agent endpoint directly to public traffic.
+
+Public-preview smoke check:
+
+```bash
+npm run smoke:public-preview
+```
+
+The smoke check builds the Web app with public-preview environment flags, starts an isolated local preview server, verifies `/api/agent/status` stays disabled, verifies `/executors` renders the public-preview boundary message, and scans responses for local paths, secret variable names, stack traces, or Agent startup details. It uses `METEORTEST_SMOKE_NO_SUPABASE=1` internally so CI can run without preview Supabase credentials; do not set this flag in Vercel. Real Vercel previews should use the configured preview Supabase environment and safe demo data.
 
 Current follow-up order:
 

--- a/apps/web/app/executors/ExecutorsPage.tsx
+++ b/apps/web/app/executors/ExecutorsPage.tsx
@@ -8,13 +8,30 @@ const statusStyle: Record<string, { bg: string; color: string; dot: string }> = 
   busy:    { bg: '#2A1A0A', color: '#F97316', dot: '#F97316' },
 }
 
+type ExecutorRow = {
+  id: string
+  name: string
+  type: string
+  status: string
+  capabilities: string[] | null
+  last_heartbeat_at: string | null
+}
+
 export default async function ExecutorsPage() {
   const locale = await getLocale()
   const t = await getDictionary()
-  const supabase = await createClient()
-  const { data: executors } = await supabase
-    .from('executors').select('id, name, type, status, capabilities, last_heartbeat_at')
-    .order('status')
+  const isPublicPreview = process.env.METEORTEST_PUBLIC_PREVIEW === '1'
+  const skipSupabaseForSmoke = process.env.METEORTEST_SMOKE_NO_SUPABASE === '1'
+  let executors: ExecutorRow[] = []
+
+  if (!skipSupabaseForSmoke) {
+    const supabase = await createClient()
+    const { data } = await supabase
+        .from('executors')
+        .select('id, name, type, status, capabilities, last_heartbeat_at')
+        .order('status')
+    executors = (data ?? []) as ExecutorRow[]
+  }
 
   return (
     <div className="page-shell space-y-6">
@@ -22,6 +39,16 @@ export default async function ExecutorsPage() {
         <h1 className="page-title">{t.pages.executors.title}</h1>
         <p className="page-subtitle">{t.pages.executors.subtitle}</p>
       </div>
+      {isPublicPreview ? (
+        <div className="data-panel rounded-xl p-4" style={{ borderColor: 'var(--accent)' }}>
+          <div className="text-xs font-semibold uppercase tracking-wide mb-2" style={{ color: 'var(--text-muted)' }}>
+            {t.agent.unavailable}
+          </div>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            {t.agent.publicUnavailableDetail}
+          </p>
+        </div>
+      ) : null}
       <AgentSupervisor />
       <div className="data-panel rounded-xl overflow-hidden">
         <table className="w-full text-sm">

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "smoke:public-preview": "node --experimental-strip-types scripts/check-public-preview.mts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",

--- a/apps/web/scripts/check-public-preview.mts
+++ b/apps/web/scripts/check-public-preview.mts
@@ -1,0 +1,192 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const host = '127.0.0.1'
+const port = process.env.METEORTEST_SMOKE_PORT || '3002'
+const baseUrl = process.env.METEORTEST_SMOKE_BASE_URL || `http://${host}:${port}`
+const nextCli = join(process.cwd(), 'node_modules', 'next', 'dist', 'bin', 'next')
+const publicPreviewEnv = {
+  ...process.env,
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://127.0.0.1:54321',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'public-preview-smoke-anon-key',
+  METEORTEST_PUBLIC_PREVIEW: '1',
+  METEORTEST_AGENT_DISABLED: '1',
+  METEORTEST_SMOKE_NO_SUPABASE: '1',
+  VERCEL: '1',
+}
+
+const forbiddenPatterns = [
+  /SUPABASE_SERVICE_ROLE_KEY/i,
+  /DEEPSEEK_API_KEY/i,
+  /METEORTEST_REPO_ROOT/i,
+  /METEORTEST_AGENT_PYTHON/i,
+  /METEORTEST_AGENT_INTERVAL/i,
+  /agent\/config\.yaml/i,
+  /C:\\Users\\/i,
+  /\/Users\/[^/\s]+/i,
+  /\/home\/[^/\s]+/i,
+  /Traceback \(most recent call last\)/i,
+  /Unhandled Runtime Error/i,
+  /Error: spawn/i,
+]
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchWithTimeout(url: string, options: RequestInit = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 5000)
+  try {
+    return await fetch(url, { ...options, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function canReach(url: string) {
+  try {
+    const response = await fetchWithTimeout(url)
+    return response.status < 500
+  } catch {
+    return false
+  }
+}
+
+function killProcessTree(child: ReturnType<typeof spawn> | null) {
+  if (!child?.pid) return
+  if (process.platform === 'win32') {
+    spawn('taskkill', ['/PID', String(child.pid), '/F', '/T'], { stdio: 'ignore' })
+    return
+  }
+  try {
+    child.kill('SIGTERM')
+  } catch {}
+}
+
+async function startServer() {
+  if (await canReach(`${baseUrl}/api/agent/status`)) {
+    console.log(`Using existing server at ${baseUrl}`)
+    return null
+  }
+
+  if (!existsSync(nextCli)) {
+    throw new Error('Missing Next.js CLI. Run npm ci or npm install in apps/web first.')
+  }
+
+  console.log('Building public-preview smoke bundle...')
+  await new Promise<void>((resolve, reject) => {
+    const build = spawn(process.execPath, [nextCli, 'build'], {
+      cwd: process.cwd(),
+      env: publicPreviewEnv,
+      stdio: 'inherit',
+    })
+    build.on('exit', (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(`next build failed with exit code ${code}`))
+    })
+    build.on('error', reject)
+  })
+
+  const child = spawn(process.execPath, [nextCli, 'start', '-H', host, '-p', port], {
+    cwd: process.cwd(),
+    env: publicPreviewEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  let output = ''
+  child.stdout.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+  child.stderr.on('data', (chunk) => {
+    output += chunk.toString()
+  })
+
+  for (let attempt = 0; attempt < 45; attempt += 1) {
+    if (await canReach(`${baseUrl}/api/agent/status`)) {
+      return child
+    }
+    await sleep(1000)
+  }
+
+  killProcessTree(child)
+  throw new Error(`Next dev server did not become ready at ${baseUrl}.\n${output.slice(-4000)}`)
+}
+
+function assertNoForbiddenText(label: string, text: string) {
+  for (const pattern of forbiddenPatterns) {
+    if (pattern.test(text)) {
+      throw new Error(`${label} contains forbidden public-preview text matching ${pattern}`)
+    }
+  }
+}
+
+async function assertAgentStatus() {
+  const getResponse = await fetchWithTimeout(`${baseUrl}/api/agent/status`)
+  if (!getResponse.ok) {
+    throw new Error(`/api/agent/status GET returned ${getResponse.status}`)
+  }
+  const getText = await getResponse.text()
+  assertNoForbiddenText('/api/agent/status GET', getText)
+
+  const status = JSON.parse(getText) as {
+    available?: boolean
+    running?: boolean
+    started?: boolean
+    pid?: number | null
+    logFile?: string
+    logTail?: string
+    publicPreview?: boolean
+  }
+  if (status.available !== false || status.running !== false || status.started !== false) {
+    throw new Error(`/api/agent/status must stay disabled in public preview: ${getText}`)
+  }
+  if (status.pid !== null || status.logFile || status.logTail) {
+    throw new Error(`/api/agent/status exposed runtime details in public preview: ${getText}`)
+  }
+  if (status.publicPreview !== true) {
+    throw new Error(`/api/agent/status did not report publicPreview=true: ${getText}`)
+  }
+
+  const postResponse = await fetchWithTimeout(`${baseUrl}/api/agent/status`, { method: 'POST' })
+  if (!postResponse.ok) {
+    throw new Error(`/api/agent/status POST returned ${postResponse.status}`)
+  }
+  const postText = await postResponse.text()
+  assertNoForbiddenText('/api/agent/status POST', postText)
+  const postStatus = JSON.parse(postText) as { started?: boolean; running?: boolean; pid?: number | null }
+  if (postStatus.started !== false || postStatus.running !== false || postStatus.pid !== null) {
+    throw new Error(`/api/agent/status POST must not start Agent in public preview: ${postText}`)
+  }
+}
+
+async function assertExecutorsPage() {
+  const response = await fetchWithTimeout(`${baseUrl}/executors`, {
+    headers: { cookie: 'meteortest.locale=en' },
+  })
+  if (!response.ok) {
+    throw new Error(`/executors returned ${response.status}`)
+  }
+  const html = await response.text()
+  assertNoForbiddenText('/executors', html)
+
+  const requiredText = [
+    'Local Agent disabled on public deployment',
+    'The public Web console only acts as an operations UI',
+  ]
+  for (const text of requiredText) {
+    if (!html.includes(text)) {
+      throw new Error(`/executors is missing public-preview boundary text: ${text}`)
+    }
+  }
+}
+
+const child = await startServer()
+try {
+  await assertAgentStatus()
+  await assertExecutorsPage()
+  console.log('Public preview smoke checks passed.')
+} finally {
+  killProcessTree(child)
+}

--- a/docs/vercel-public-preview.md
+++ b/docs/vercel-public-preview.md
@@ -65,10 +65,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-preview-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-preview-service-role-key
 DEEPSEEK_API_KEY=optional
 METEORTEST_AGENT_DISABLED=1
-METEORTEST_PUBLIC_PREVIEW=1 once implemented
+METEORTEST_PUBLIC_PREVIEW=1
 ```
 
 Use Vercel Project Settings for these values. Do not commit `.env.local`.
+
+Do not configure `METEORTEST_SMOKE_NO_SUPABASE` in Vercel. That flag is only for CI smoke checks that must verify public-preview safety without requiring real Supabase credentials.
 
 Important boundaries:
 
@@ -117,6 +119,14 @@ The seed creates a demo `iOS-Automation-Framework` project, `api_smoke` suite, p
 If an environment variable changes later, redeploy. Vercel environment variable changes do not modify already-created deployments.
 
 ## First Smoke Check After Deployment
+
+Before or after a deployment change, the repository CI runs:
+
+```bash
+npm run smoke:public-preview
+```
+
+This local smoke check builds the Web app with public-preview flags, starts an isolated preview server, verifies `/api/agent/status` stays disabled, verifies `/executors` renders the public-preview boundary, and scans for local paths, secret variable names, stack traces, or Agent startup details. It deliberately uses `METEORTEST_SMOKE_NO_SUPABASE=1`; the live Vercel preview should use the Supabase variables configured in Project Settings.
 
 Open the deployment URL and check:
 

--- a/docs/vercel-public-preview.zh-CN.md
+++ b/docs/vercel-public-preview.zh-CN.md
@@ -65,10 +65,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-preview-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-preview-service-role-key
 DEEPSEEK_API_KEY=可选
 METEORTEST_AGENT_DISABLED=1
-METEORTEST_PUBLIC_PREVIEW=1 完成代码支持后启用
+METEORTEST_PUBLIC_PREVIEW=1
 ```
 
 这些值要配置在 Vercel Project Settings 中，不要提交 `.env.local`。
+
+不要在 Vercel 中配置 `METEORTEST_SMOKE_NO_SUPABASE`。这个变量只给 CI smoke check 使用，用来在没有真实 Supabase 密钥的情况下验证公网预览安全边界。
 
 重要边界：
 
@@ -117,6 +119,14 @@ supabase/seed-preview.sql
 如果后续修改了环境变量，需要重新部署。Vercel 的环境变量变更不会影响已经创建的旧部署。
 
 ## 部署后的第一次 smoke check
+
+部署前后，仓库 CI 会运行：
+
+```bash
+npm run smoke:public-preview
+```
+
+这个本地 smoke check 会用公网预览开关构建 Web 应用，启动隔离的预览服务，验证 `/api/agent/status` 保持 disabled，验证 `/executors` 渲染公网预览边界提示，并扫描本机路径、密钥变量名、堆栈信息或 Agent 启动入口。它会故意使用 `METEORTEST_SMOKE_NO_SUPABASE=1`；真实 Vercel 预览应该使用 Project Settings 中配置的 Supabase 变量。
 
 打开部署 URL，检查：
 


### PR DESCRIPTION
## Summary
Add public-preview smoke checks for MeteorTest Web so CI verifies that public deployments do not expose Local Agent startup paths or local runtime details.

## Changes
- Added a TypeScript public-preview smoke script for /api/agent/status and /executors.
- Added the smoke check to the Web CI job.
- Updated /executors to render a server-side public-preview boundary while keeping real Vercel Supabase data enabled.
- Updated AGENTS, PROGRESS, Web README, and Vercel runbooks to document the CI-only no-Supabase smoke mode.

## Test Plan
- npm run lint
- npm run build
- npm run smoke:public-preview
- python -m pytest agent\\tests -q

Closes #61