### PR TITLE
[Feature] Add preview access gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,8 @@ For public Web preview work:
 - For Vercel deployment, follow `docs/vercel-public-preview.md` and `docs/vercel-public-preview.zh-CN.md`.
 - The current public preview URL is `https://meteortest.jcmeteor.com/`.
 - The current hardening sequence is recorded in `PROGRESS.md`: public preview mode, access protection, preview seed data, task/report experience, then private-Agent online loop.
-- Public preview deployments should set `METEORTEST_AGENT_DISABLED=1`; prefer also setting `METEORTEST_PUBLIC_PREVIEW=1` once the code path is implemented.
+- Public preview deployments should set `METEORTEST_AGENT_DISABLED=1` and `METEORTEST_PUBLIC_PREVIEW=1`.
+- If a public preview should not be openly browseable, set `METEORTEST_PREVIEW_ACCESS_TOKEN` in the deployment provider. Do not commit it, expose it as `NEXT_PUBLIC_*`, or paste it into issues, PRs, screenshots, or docs.
 - In public preview mode, `/api/agent/status` and the Executors page must never attempt to start a machine-local Agent. They should show a clear disabled/unavailable state and instruct the operator to run the Agent privately.
 - Do not add public Web preview links to the personal website without preserving this boundary: Web preview is online, Local Agent execution is private, and public connected execution is deferred.
 
@@ -381,6 +382,8 @@ Keep `MeteorTest` as the engineering/product English name.
 ### Next.js Route File Structure
 
 Next.js App Router requires route entry files such as `page.tsx`; do not rename those files directly or routes will break.
+
+For app-wide request interception in Next.js 16, use `apps/web/proxy.ts`. Do not add new `middleware.ts` files; that convention is deprecated in the current Next.js version.
 
 For non-trivial pages, keep `page.tsx` as a thin route entry and move business UI into a named sibling component, for example:
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -47,13 +47,14 @@
 - [x] Vercel runbook 明确不要配置 `METEORTEST_REPO_ROOT`、`METEORTEST_AGENT_PYTHON`、`METEORTEST_AGENT_INTERVAL` 或本机路径
 - [x] Smoke check 覆盖 `/executors` 和 `/api/agent/status`，确认不暴露本机路径、栈信息、密钥或 Agent 启动入口
   - `apps/web/scripts/check-public-preview.mts` 使用 public-preview 环境构建并启动独立 smoke server。
-  - CI 通过 `npm run smoke:public-preview` 验证 `/api/agent/status` 禁用 Agent 控制、`/executors` 服务端渲染 public preview 边界提示，并扫描响应中是否出现本机路径、密钥变量、栈信息或 Agent 启动入口。
+  - CI 通过 `npm run smoke:public-preview` 验证 preview access gate、`/api/agent/status` 禁用 Agent 控制、`/executors` 服务端渲染 public preview 边界提示，并扫描响应中是否出现本机路径、密钥变量、栈信息或 Agent 启动入口。
   - smoke 使用 `METEORTEST_SMOKE_NO_SUPABASE=1` 跳过 Supabase 查询；Vercel 真实公网预览已配置 Supabase 密钥时仍可正常展示 preview 数据。
 
 ### Authentication And Access Control
 
 - [ ] 短期：启用 Vercel Deployment Protection、Vercel Password 或等价访问保护
-- [ ] 在 `docs/vercel-public-preview.md` 和中文文档中记录当前访问保护方式
+- [x] 增加应用级 `METEORTEST_PREVIEW_ACCESS_TOKEN` 访问门禁，供公网预览在 Vercel 环境变量中启用
+- [x] 在 `docs/vercel-public-preview.md` 和中文文档中记录访问保护方式与 token 边界
 - [ ] 中期：设计 Supabase Auth 登录页、会话状态、API route 鉴权和 viewer/operator/admin 角色边界
 - [ ] 长期：把任务创建、构建登记、AI 分析、执行器控制等操作拆分权限
 

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -18,6 +18,11 @@ SUPABASE_SERVICE_ROLE_KEY=
 METEORTEST_AGENT_DISABLED=1
 METEORTEST_PUBLIC_PREVIEW=1
 
+# Optional app-level public preview gate. Configure this in Vercel Project
+# Settings if the preview should require a shared access token before loading
+# pages or API routes.
+METEORTEST_PREVIEW_ACCESS_TOKEN=
+
 # Local Agent settings are intentionally not part of the public preview config.
 # Configure the Agent separately in agent/config.yaml and local environment
 # variables when you run private execution from your own machine.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -65,11 +65,13 @@ Use this order when opening MeteorTest Web on the public internet:
    DEEPSEEK_API_KEY optional
    METEORTEST_AGENT_DISABLED=1
    METEORTEST_PUBLIC_PREVIEW=1
+   METEORTEST_PREVIEW_ACCESS_TOKEN optional
    ```
 
-4. Keep `METEORTEST_REPO_ROOT`, `METEORTEST_AGENT_PYTHON`, `METEORTEST_AGENT_INTERVAL`, local repository paths, and local Agent config out of the public Web deployment unless a reviewed execution-safety design exists.
-5. Deploy `apps/web` with Node.js 22, `npm ci`, and `npm run build`.
-6. Smoke-check the public URL:
+4. Optionally set `METEORTEST_PREVIEW_ACCESS_TOKEN` to enable an app-level access gate for the public preview. Visitors must enter this token before pages load; API callers can send it through the `x-meteortest-preview-token` header.
+5. Keep `METEORTEST_REPO_ROOT`, `METEORTEST_AGENT_PYTHON`, `METEORTEST_AGENT_INTERVAL`, local repository paths, and local Agent config out of the public Web deployment unless a reviewed execution-safety design exists.
+6. Deploy `apps/web` with Node.js 22, `npm ci`, and `npm run build`.
+7. Smoke-check the public URL:
 
    - Dashboard loads.
    - Projects, tasks, reports, builds, executors, and settings routes load.
@@ -77,7 +79,7 @@ Use this order when opening MeteorTest Web on the public internet:
    - Executor controls do not expose a public Local Agent endpoint.
    - AI assistant returns a clear unavailable state if `DEEPSEEK_API_KEY` is not configured.
 
-7. Only after the Web preview is stable, decide whether a private Local Agent should poll the preview backend with scoped credentials. Do not expose a machine-local Agent endpoint directly to public traffic.
+8. Only after the Web preview is stable, decide whether a private Local Agent should poll the preview backend with scoped credentials. Do not expose a machine-local Agent endpoint directly to public traffic.
 
 Public-preview smoke check:
 
@@ -85,12 +87,12 @@ Public-preview smoke check:
 npm run smoke:public-preview
 ```
 
-The smoke check builds the Web app with public-preview environment flags, starts an isolated local preview server, verifies `/api/agent/status` stays disabled, verifies `/executors` renders the public-preview boundary message, and scans responses for local paths, secret variable names, stack traces, or Agent startup details. It uses `METEORTEST_SMOKE_NO_SUPABASE=1` internally so CI can run without preview Supabase credentials; do not set this flag in Vercel. Real Vercel previews should use the configured preview Supabase environment and safe demo data.
+The smoke check builds the Web app with public-preview environment flags, starts an isolated local preview server, verifies the optional preview access gate, verifies `/api/agent/status` stays disabled, verifies `/executors` renders the public-preview boundary message, and scans responses for local paths, secret variable names, stack traces, or Agent startup details. It uses `METEORTEST_SMOKE_NO_SUPABASE=1` internally so CI can run without preview Supabase credentials; do not set this flag in Vercel. Real Vercel previews should use the configured preview Supabase environment and safe demo data.
 
 Current follow-up order:
 
 1. Harden public preview mode so public deployments never try to start a machine-local Agent.
-2. Add access protection before treating the preview as a long-lived public console.
+2. Enable access protection before treating the preview as a long-lived public console. Use Vercel Deployment Protection, `METEORTEST_PREVIEW_ACCESS_TOKEN`, or both.
 3. Seed safe demo data for dashboard, projects, tasks, reports, executors, and builds.
 4. Improve task detail and report analysis surfaces around status, logs, failure category, AI analysis, and next actions.
 5. Run a private Local Agent against the preview backend only after the preview boundary is stable.

--- a/apps/web/app/api/preview-access/route.ts
+++ b/apps/web/app/api/preview-access/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  isPreviewAccessEnabled,
+  isValidPreviewAccessToken,
+  previewAccessCookieName,
+  sanitizeNextPath,
+} from '@/lib/previewAccess'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData()
+  const token = formData.get('accessToken')
+  const nextPath = sanitizeNextPath(formData.get('next')?.toString())
+
+  if (!isPreviewAccessEnabled()) {
+    return NextResponse.redirect(new URL(nextPath, request.url), 303)
+  }
+
+  if (typeof token !== 'string' || !isValidPreviewAccessToken(token.trim())) {
+    const redirectUrl = new URL('/preview-access', request.url)
+    redirectUrl.searchParams.set('error', '1')
+    redirectUrl.searchParams.set('next', nextPath)
+    return NextResponse.redirect(redirectUrl, 303)
+  }
+
+  const response = NextResponse.redirect(new URL(nextPath, request.url), 303)
+  response.cookies.set(previewAccessCookieName, token.trim(), {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 60 * 60 * 12,
+  })
+  return response
+}

--- a/apps/web/app/preview-access/PreviewAccessPage.tsx
+++ b/apps/web/app/preview-access/PreviewAccessPage.tsx
@@ -1,0 +1,55 @@
+import { getDictionary } from '@/lib/i18n'
+import { sanitizeNextPath } from '@/lib/previewAccess'
+
+export default async function PreviewAccessPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; next?: string }>
+}) {
+  const t = await getDictionary()
+  const { error, next } = await searchParams
+  const nextPath = sanitizeNextPath(next)
+
+  return (
+    <div className="page-shell min-h-[calc(100vh-3rem)] flex items-center justify-center">
+      <section className="console-hero w-full max-w-xl rounded-2xl p-6">
+        <div className="mb-6">
+          <div className="kicker mb-3">{t.previewAccess.kicker}</div>
+          <h1 className="page-title">{t.previewAccess.title}</h1>
+          <p className="page-subtitle">{t.previewAccess.description}</p>
+        </div>
+
+        <form action="/api/preview-access" method="post" className="space-y-4">
+          <input type="hidden" name="next" value={nextPath} />
+          <label className="block">
+            <span className="mb-2 block text-sm font-semibold" style={{ color: 'var(--text-secondary)' }}>
+              {t.previewAccess.tokenLabel}
+            </span>
+            <input
+              className="field-input px-4 py-3"
+              name="accessToken"
+              type="password"
+              autoComplete="current-password"
+              required
+              placeholder={t.previewAccess.tokenPlaceholder}
+            />
+          </label>
+
+          {error ? (
+            <div className="notice-banner rounded-xl px-4 py-3 text-sm" style={{ borderColor: 'var(--status-failed-text)' }}>
+              {t.previewAccess.invalidToken}
+            </div>
+          ) : null}
+
+          <button type="submit" className="primary-action w-full rounded-xl px-4 py-3 text-sm font-semibold">
+            {t.previewAccess.submit}
+          </button>
+        </form>
+
+        <p className="mt-5 text-xs leading-5" style={{ color: 'var(--text-muted)' }}>
+          {t.previewAccess.footer}
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/app/preview-access/page.tsx
+++ b/apps/web/app/preview-access/page.tsx
@@ -1,0 +1,1 @@
+export { default } from './PreviewAccessPage'

--- a/apps/web/content/i18n.ts
+++ b/apps/web/content/i18n.ts
@@ -226,6 +226,16 @@ export const dictionaries = {
       emptyResponse: 'Agent 状态接口返回为空',
       invalidResponse: 'Agent 状态接口返回格式异常',
     },
+    previewAccess: {
+      kicker: 'PUBLIC PREVIEW ACCESS',
+      title: '访问 MeteorTest 公网预览',
+      description: '这个预览环境用于验证 Web 控制台和安全 demo 数据。请输入预览访问口令后继续。',
+      tokenLabel: '访问口令',
+      tokenPlaceholder: '输入预览访问口令',
+      invalidToken: '访问口令不正确，请重新输入。',
+      submit: '进入预览',
+      footer: 'Local Agent 执行仍保持私有；公网预览不会直接启动本机执行器。',
+    },
     forms: {
       projectName: '项目名称',
       projectKey: '项目标识',
@@ -576,6 +586,16 @@ export const dictionaries = {
       checkFailed: 'Unable to check Agent status',
       emptyResponse: 'Agent status API returned an empty response',
       invalidResponse: 'Agent status API returned an invalid response',
+    },
+    previewAccess: {
+      kicker: 'PUBLIC PREVIEW ACCESS',
+      title: 'Access the MeteorTest public preview',
+      description: 'This preview environment is for validating the Web console and safe demo data. Enter the preview access token to continue.',
+      tokenLabel: 'Access token',
+      tokenPlaceholder: 'Enter preview access token',
+      invalidToken: 'The access token is incorrect. Please try again.',
+      submit: 'Enter preview',
+      footer: 'Local Agent execution remains private; the public preview does not start machine-local executors.',
     },
     forms: {
       projectName: 'Project name',

--- a/apps/web/lib/previewAccess.ts
+++ b/apps/web/lib/previewAccess.ts
@@ -1,0 +1,20 @@
+export const previewAccessCookieName = 'meteortest.preview_access'
+export const previewAccessTokenHeader = 'x-meteortest-preview-token'
+
+export function getPreviewAccessToken() {
+  return process.env.METEORTEST_PREVIEW_ACCESS_TOKEN?.trim() || ''
+}
+
+export function isPreviewAccessEnabled() {
+  return process.env.METEORTEST_PUBLIC_PREVIEW === '1' && Boolean(getPreviewAccessToken())
+}
+
+export function isValidPreviewAccessToken(value?: string | null) {
+  const expected = getPreviewAccessToken()
+  return Boolean(expected && value && value === expected)
+}
+
+export function sanitizeNextPath(value?: string | null) {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return '/'
+  return value
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  isPreviewAccessEnabled,
+  isValidPreviewAccessToken,
+  previewAccessCookieName,
+  previewAccessTokenHeader,
+} from '@/lib/previewAccess'
+
+const publicPaths = new Set(['/preview-access', '/api/preview-access', '/favicon.ico'])
+
+function hasPreviewAccess(request: NextRequest) {
+  const cookieToken = request.cookies.get(previewAccessCookieName)?.value
+  const headerToken = request.headers.get(previewAccessTokenHeader)
+  return isValidPreviewAccessToken(cookieToken) || isValidPreviewAccessToken(headerToken)
+}
+
+export function proxy(request: NextRequest) {
+  if (!isPreviewAccessEnabled()) return NextResponse.next()
+
+  const { pathname, search } = request.nextUrl
+  if (publicPaths.has(pathname) || pathname.startsWith('/_next/')) {
+    return NextResponse.next()
+  }
+
+  if (hasPreviewAccess(request)) return NextResponse.next()
+
+  if (pathname.startsWith('/api/')) {
+    return NextResponse.json({ error: 'Preview access required' }, { status: 401 })
+  }
+
+  const redirectUrl = request.nextUrl.clone()
+  redirectUrl.pathname = '/preview-access'
+  redirectUrl.search = ''
+  redirectUrl.searchParams.set('next', `${pathname}${search}`)
+  return NextResponse.redirect(redirectUrl)
+}
+
+export const config = {
+  matcher: ['/((?!.*\\..*).*)', '/api/:path*', '/favicon.ico'],
+}

--- a/apps/web/scripts/check-public-preview.mts
+++ b/apps/web/scripts/check-public-preview.mts
@@ -6,6 +6,7 @@ const host = '127.0.0.1'
 const port = process.env.METEORTEST_SMOKE_PORT || '3002'
 const baseUrl = process.env.METEORTEST_SMOKE_BASE_URL || `http://${host}:${port}`
 const nextCli = join(process.cwd(), 'node_modules', 'next', 'dist', 'bin', 'next')
+const previewAccessToken = 'public-preview-smoke-token'
 const publicPreviewEnv = {
   ...process.env,
   NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://127.0.0.1:54321',
@@ -13,6 +14,7 @@ const publicPreviewEnv = {
   METEORTEST_PUBLIC_PREVIEW: '1',
   METEORTEST_AGENT_DISABLED: '1',
   METEORTEST_SMOKE_NO_SUPABASE: '1',
+  METEORTEST_PREVIEW_ACCESS_TOKEN: previewAccessToken,
   VERCEL: '1',
 }
 
@@ -45,9 +47,18 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}) {
   }
 }
 
+function withPreviewAccess(options: RequestInit = {}): RequestInit {
+  const headers = new Headers(options.headers)
+  headers.set('x-meteortest-preview-token', previewAccessToken)
+  return {
+    ...options,
+    headers,
+  }
+}
+
 async function canReach(url: string) {
   try {
-    const response = await fetchWithTimeout(url)
+    const response = await fetchWithTimeout(url, withPreviewAccess())
     return response.status < 500
   } catch {
     return false
@@ -123,7 +134,7 @@ function assertNoForbiddenText(label: string, text: string) {
 }
 
 async function assertAgentStatus() {
-  const getResponse = await fetchWithTimeout(`${baseUrl}/api/agent/status`)
+  const getResponse = await fetchWithTimeout(`${baseUrl}/api/agent/status`, withPreviewAccess())
   if (!getResponse.ok) {
     throw new Error(`/api/agent/status GET returned ${getResponse.status}`)
   }
@@ -149,7 +160,7 @@ async function assertAgentStatus() {
     throw new Error(`/api/agent/status did not report publicPreview=true: ${getText}`)
   }
 
-  const postResponse = await fetchWithTimeout(`${baseUrl}/api/agent/status`, { method: 'POST' })
+  const postResponse = await fetchWithTimeout(`${baseUrl}/api/agent/status`, withPreviewAccess({ method: 'POST' }))
   if (!postResponse.ok) {
     throw new Error(`/api/agent/status POST returned ${postResponse.status}`)
   }
@@ -162,9 +173,9 @@ async function assertAgentStatus() {
 }
 
 async function assertExecutorsPage() {
-  const response = await fetchWithTimeout(`${baseUrl}/executors`, {
+  const response = await fetchWithTimeout(`${baseUrl}/executors`, withPreviewAccess({
     headers: { cookie: 'meteortest.locale=en' },
-  })
+  }))
   if (!response.ok) {
     throw new Error(`/executors returned ${response.status}`)
   }
@@ -182,8 +193,25 @@ async function assertExecutorsPage() {
   }
 }
 
+async function assertPreviewAccessGate() {
+  const apiResponse = await fetchWithTimeout(`${baseUrl}/api/agent/status`)
+  if (apiResponse.status !== 401) {
+    throw new Error(`/api/agent/status must require preview access when a token is configured: ${apiResponse.status}`)
+  }
+
+  const pageResponse = await fetchWithTimeout(`${baseUrl}/executors`, { redirect: 'manual' })
+  if (![302, 307, 308].includes(pageResponse.status)) {
+    throw new Error(`/executors must redirect to preview access when a token is configured: ${pageResponse.status}`)
+  }
+  const location = pageResponse.headers.get('location') ?? ''
+  if (!location.includes('/preview-access')) {
+    throw new Error(`/executors redirected to an unexpected location: ${location}`)
+  }
+}
+
 const child = await startServer()
 try {
+  await assertPreviewAccessGate()
   await assertAgentStatus()
   await assertExecutorsPage()
   console.log('Public preview smoke checks passed.')

--- a/docs/vercel-public-preview.md
+++ b/docs/vercel-public-preview.md
@@ -66,9 +66,12 @@ SUPABASE_SERVICE_ROLE_KEY=your-preview-service-role-key
 DEEPSEEK_API_KEY=optional
 METEORTEST_AGENT_DISABLED=1
 METEORTEST_PUBLIC_PREVIEW=1
+METEORTEST_PREVIEW_ACCESS_TOKEN=optional-shared-preview-token
 ```
 
 Use Vercel Project Settings for these values. Do not commit `.env.local`.
+
+`METEORTEST_PREVIEW_ACCESS_TOKEN` enables the app-level preview gate. When it is set together with `METEORTEST_PUBLIC_PREVIEW=1`, visitors must enter the token before loading pages. API callers can pass the same value in the `x-meteortest-preview-token` header. Leave it empty only for short-lived previews that are already protected by Vercel Deployment Protection or another access control layer.
 
 Do not configure `METEORTEST_SMOKE_NO_SUPABASE` in Vercel. That flag is only for CI smoke checks that must verify public-preview safety without requiring real Supabase credentials.
 
@@ -79,6 +82,7 @@ Important boundaries:
 - Never add the `NEXT_PUBLIC_` prefix to service-role or AI provider keys.
 - Do not configure `METEORTEST_REPO_ROOT`, `METEORTEST_AGENT_PYTHON`, `METEORTEST_AGENT_INTERVAL`, local repository paths, or local Agent config in the public deployment unless an execution-safety design exists.
 - Public preview deployments must not attempt to spawn a Local Agent. `/executors` and `/api/agent/status` should show a disabled/unavailable state.
+- If `METEORTEST_PREVIEW_ACCESS_TOKEN` is set, keep it server-only in Vercel Project Settings and do not paste it into issues, PR bodies, screenshots, or client code.
 
 ## Supabase Preview Setup
 
@@ -126,7 +130,7 @@ Before or after a deployment change, the repository CI runs:
 npm run smoke:public-preview
 ```
 
-This local smoke check builds the Web app with public-preview flags, starts an isolated preview server, verifies `/api/agent/status` stays disabled, verifies `/executors` renders the public-preview boundary, and scans for local paths, secret variable names, stack traces, or Agent startup details. It deliberately uses `METEORTEST_SMOKE_NO_SUPABASE=1`; the live Vercel preview should use the Supabase variables configured in Project Settings.
+This local smoke check builds the Web app with public-preview flags, starts an isolated preview server, verifies the preview access gate, verifies `/api/agent/status` stays disabled, verifies `/executors` renders the public-preview boundary, and scans for local paths, secret variable names, stack traces, or Agent startup details. It deliberately uses `METEORTEST_SMOKE_NO_SUPABASE=1`; the live Vercel preview should use the Supabase variables configured in Project Settings.
 
 Open the deployment URL and check:
 
@@ -153,7 +157,7 @@ Only after the URL is verified:
 Then continue hardening in this order:
 
 1. Public preview mode: make Agent startup impossible in public deployments and document the unavailable state.
-2. Access protection: enable Vercel Deployment Protection, Vercel Password, or an equivalent guard before long-lived public use.
+2. Access protection: enable Vercel Deployment Protection, `METEORTEST_PREVIEW_ACCESS_TOKEN`, or an equivalent guard before long-lived public use.
 3. Preview data: run `supabase/seed-preview.sql` to seed safe demo projects, suites, tasks, reports, executors, and builds.
 4. Task/report experience: make failed-task analysis readable through status, logs, failure category, AI analysis, and next actions.
 5. Private Agent loop: connect a private Local Agent to the preview backend only after the above is stable.

--- a/docs/vercel-public-preview.zh-CN.md
+++ b/docs/vercel-public-preview.zh-CN.md
@@ -66,9 +66,12 @@ SUPABASE_SERVICE_ROLE_KEY=your-preview-service-role-key
 DEEPSEEK_API_KEY=可选
 METEORTEST_AGENT_DISABLED=1
 METEORTEST_PUBLIC_PREVIEW=1
+METEORTEST_PREVIEW_ACCESS_TOKEN=可选的共享预览口令
 ```
 
 这些值要配置在 Vercel Project Settings 中，不要提交 `.env.local`。
+
+`METEORTEST_PREVIEW_ACCESS_TOKEN` 会启用应用级预览访问门禁。它和 `METEORTEST_PUBLIC_PREVIEW=1` 同时存在时，访问者需要先输入口令才能加载页面。API 调用方可以通过 `x-meteortest-preview-token` 请求头传入同一个值。只有在 Vercel Deployment Protection 或其他访问控制已经启用的短期预览中，才建议留空。
 
 不要在 Vercel 中配置 `METEORTEST_SMOKE_NO_SUPABASE`。这个变量只给 CI smoke check 使用，用来在没有真实 Supabase 密钥的情况下验证公网预览安全边界。
 
@@ -79,6 +82,7 @@ METEORTEST_PUBLIC_PREVIEW=1
 - 不要给 service-role key 或 AI 服务 key 加 `NEXT_PUBLIC_` 前缀。
 - 不要在公网部署中配置 `METEORTEST_REPO_ROOT`、`METEORTEST_AGENT_PYTHON`、`METEORTEST_AGENT_INTERVAL`、本地仓库路径或本机 Agent 配置，除非已经完成执行安全设计。
 - 公网预览部署不得尝试启动 Local Agent。`/executors` 和 `/api/agent/status` 应显示 disabled/unavailable 状态。
+- 如果配置了 `METEORTEST_PREVIEW_ACCESS_TOKEN`，它只能放在 Vercel Project Settings 服务端环境中，不要粘贴到 issue、PR 描述、截图或客户端代码里。
 
 ## Supabase 预览环境
 
@@ -126,7 +130,7 @@ supabase/seed-preview.sql
 npm run smoke:public-preview
 ```
 
-这个本地 smoke check 会用公网预览开关构建 Web 应用，启动隔离的预览服务，验证 `/api/agent/status` 保持 disabled，验证 `/executors` 渲染公网预览边界提示，并扫描本机路径、密钥变量名、堆栈信息或 Agent 启动入口。它会故意使用 `METEORTEST_SMOKE_NO_SUPABASE=1`；真实 Vercel 预览应该使用 Project Settings 中配置的 Supabase 变量。
+这个本地 smoke check 会用公网预览开关构建 Web 应用，启动隔离的预览服务，验证预览访问门禁，验证 `/api/agent/status` 保持 disabled，验证 `/executors` 渲染公网预览边界提示，并扫描本机路径、密钥变量名、堆栈信息或 Agent 启动入口。它会故意使用 `METEORTEST_SMOKE_NO_SUPABASE=1`；真实 Vercel 预览应该使用 Project Settings 中配置的 Supabase 变量。
 
 打开部署 URL，检查：
 
@@ -153,7 +157,7 @@ npm run smoke:public-preview
 然后按这个顺序继续加固：
 
 1. 公网预览模式：确保公网部署不可能启动本机 Agent，并记录不可用状态。
-2. 访问保护：长期公开前启用 Vercel Deployment Protection、Vercel Password 或等价保护。
+2. 访问保护：长期公开前启用 Vercel Deployment Protection、`METEORTEST_PREVIEW_ACCESS_TOKEN` 或等价保护。
 3. 预览数据：执行 `supabase/seed-preview.sql` 初始化安全 demo 项目、suite、任务、报告、执行器和构建数据。
 4. 任务/报告体验：通过状态、日志、失败分类、AI 分析和下一步建议，让 failed task 可读。
 5. 私有 Agent 闭环：上述稳定后，再让私有 Local Agent 连接 preview backend。


### PR DESCRIPTION
## Summary
Add an optional app-level access gate for MeteorTest public preview deployments so long-lived Vercel previews do not have to stay openly browseable.

## Changes
- Added Next.js 16 proxy-based preview access enforcement.
- Added /preview-access UI and /api/preview-access token submission route.
- Added shared preview access helpers and localized English/Chinese copy.
- Extended public-preview smoke checks to verify unauthorized requests are blocked and authorized requests still pass the Local Agent boundary checks.
- Updated .env.local.example, AGENTS, PROGRESS, Web README, and Vercel runbooks.

## Test Plan
- npm run lint
- npm run build
- npm run smoke:public-preview
- python -m pytest agent\\tests -q

Closes #63