### PR TITLE
[Feature] Add Local Agent operations and resource-saving plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Additional docs:
 - [AI and LangChain modernization plan](docs/ai-langchain-modernization-plan.md)
 - [Supabase account and account-scoped data SQL runbook](docs/supabase-account-data-runbook.md)
 - [Private Agent preview loop](docs/private-agent-preview-loop.md)
+- [Local Agent operations](docs/local-agent-operations.md)
 
 ## Maintainer
 
@@ -343,6 +344,33 @@ $env:SUPABASE_ARTIFACT_BUCKET="test-artifacts"
 ```
 
 ### 3. Start the Agent
+
+For daily local use, run this from the repository root:
+
+```bash
+./scripts/start-local-agent.sh
+```
+
+The script reads `apps/web/.env.local`, reuses `agent/config.yaml`, and defaults to claiming only Web-console private preview tasks.
+
+To keep the Agent running on macOS, install the user-level `launchd` service:
+
+```bash
+./scripts/install-local-agent-launchd.sh
+```
+
+After installation, the Agent starts at login and is restarted if it exits. Common management commands:
+
+```bash
+launchctl list | grep com.meteortest.local-agent
+./scripts/check-local-agent.sh
+./scripts/restart-local-agent-launchd.sh
+./scripts/uninstall-local-agent-launchd.sh
+tail -f .meteortest-agent/logs/launchd.out.log
+tail -f .meteortest-agent/logs/launchd.err.log
+```
+
+For manual startup:
 
 ```bash
 python -m agent.agent --config agent/config.yaml --interval 10

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,7 @@ MeteorTest 是一个通用自动化测试平台，用来管理多个测试项目
 - [AI 与 LangChain 渐进改造方案](docs/ai-langchain-modernization-plan.zh-CN.md)
 - [Supabase 账号与账号级数据 SQL 执行手册](docs/supabase-account-data-runbook.zh-CN.md)
 - [私有 Agent 预览闭环](docs/private-agent-preview-loop.zh-CN.md)
+- [Local Agent 运维方式](docs/local-agent-operations.zh-CN.md)
 
 ## 维护者
 
@@ -343,6 +344,33 @@ $env:SUPABASE_ARTIFACT_BUCKET="test-artifacts"
 ```
 
 ### 3. 启动 Agent
+
+本机日常使用推荐在仓库根目录运行：
+
+```bash
+./scripts/start-local-agent.sh
+```
+
+这个脚本会读取 `apps/web/.env.local`，复用 `agent/config.yaml`，并默认只领取 Web 控制台创建的 private preview 任务。
+
+如果希望 Agent 常驻，macOS 推荐安装用户级 `launchd` 服务：
+
+```bash
+./scripts/install-local-agent-launchd.sh
+```
+
+安装后会在登录时自动启动，并在进程退出时自动拉起。常用管理命令：
+
+```bash
+launchctl list | grep com.meteortest.local-agent
+./scripts/check-local-agent.sh
+./scripts/restart-local-agent-launchd.sh
+./scripts/uninstall-local-agent-launchd.sh
+tail -f .meteortest-agent/logs/launchd.out.log
+tail -f .meteortest-agent/logs/launchd.err.log
+```
+
+如需手动启动：
 
 ```bash
 python -m agent.agent --config agent/config.yaml --interval 10

--- a/docs/local-agent-operations.md
+++ b/docs/local-agent-operations.md
@@ -1,0 +1,196 @@
+# Local Agent Operations
+
+Updated: 2026-05-13
+
+Local Agent operations should be viewed in two layers:
+
+- macOS `launchd` keeps the local process alive.
+- Supabase is the source of truth for platform feedback.
+- The Web console reads executor, task, report, and AI analysis data from Supabase.
+
+## Recommended Supervisor
+
+Run once from the MeteorTest repository root:
+
+```bash
+./scripts/install-local-agent-launchd.sh
+```
+
+This installs a user-level `launchd` service:
+
+- Starts after macOS login.
+- Restarts the process if it exits.
+- Uses `scripts/start-local-agent.sh`.
+- Reads environment variables from `apps/web/.env.local`.
+- Reads Agent configuration from `agent/config.yaml`.
+
+## Platform-Configurable Task Check Frequency
+
+The product goal is not to expose polling or heartbeat internals. The goal is a local-server resource-saving mode:
+
+- Keep the local Agent resident and ready.
+- Reduce Supabase requests when there are no tasks.
+- Let low-volume periods check less often to save local and Supabase resources.
+- Let operators temporarily speed it up when fast execution is needed.
+- Keep Supabase as the source of truth for task results, reports, logs, and AI analysis.
+
+This setting only controls how often the Agent checks for new tasks. It does not control online heartbeat.
+
+Recommended fixed heartbeat: `120s`.
+
+- Heartbeat only updates `executors.status` and `executors.last_heartbeat_at`, so its resource cost is very small.
+- A long heartbeat interval makes it harder for the Web console to know whether the Agent is actually online.
+- Even when task check frequency is set to `60min`, the Agent should still keep sending a fixed heartbeat to say “I am alive.”
+
+Final strategy:
+
+```text
+Task check frequency: controlled by the Settings segmented slider, from 30s to 60min.
+Agent online heartbeat: fixed at 120s, independent from task check frequency.
+```
+
+Recommended Settings copy:
+
+```text
+Task check frequency
+Control how often the Local Agent checks for new tasks. Lower frequency saves resources, but new tasks start later.
+```
+
+Recommended default: `5m`.
+
+Segmented time density:
+
+| Step | Label | Value | Scenario |
+| --- | --- | ---: | --- |
+| 1 | 30s | 30 seconds | Active debugging or immediate execution |
+| 2 | 1m | 60 seconds | Short task bursts |
+| 3 | 5m | 300 seconds | Recommended default balancing response and cost |
+| 4 | 10m | 600 seconds | Low task volume with moderate responsiveness |
+| 5 | 15m | 900 seconds | Daily low-frequency usage |
+| 6 | 30min | 1800 seconds | Occasional half-day checks |
+| 7 | 45min | 2700 seconds | Very low task volume |
+| 8 | 60min | 3600 seconds | Maximum resource saving |
+
+Settings interaction:
+
+- Use a segmented slider instead of free numeric input.
+- Only allow the 8 values listed above.
+- Show the active value as “Checks for new tasks about every X”.
+- Show helper text explaining the faster/slower tradeoff.
+- Save to Supabase; the Agent applies the next loaded config.
+
+Data and permissions:
+
+- Store this as platform-level Agent runtime configuration, not browser-local settings.
+- Only `admin` can modify it.
+- `viewer` and `operator` can see the active strategy but cannot edit it.
+- Keep `agent/config.yaml` as a startup fallback. Platform config wins when available.
+
+Recommended table:
+
+```text
+agent_runtime_settings
+- id
+- executor_name
+- enabled
+- task_check_interval_seconds
+- task_source
+- private_preview_only
+- updated_by
+- updated_at
+```
+
+Runtime behavior:
+
+- Agent reads platform config after startup.
+- While idle, it waits `task_check_interval_seconds` before checking again.
+- Agent online heartbeat stays fixed and low-frequency, for example `120s`, independent from `task_check_interval_seconds`.
+- Agent refreshes config periodically so Settings changes apply without restart.
+- If platform config cannot be read, fall back to local config or script defaults.
+- Running tasks are not interrupted; the new interval applies from the next idle check.
+
+Acceptance:
+
+- Settings can select `30s / 1m / 5m / 10m / 15m / 30min / 45min / 60min` with a segmented slider.
+- Refreshing Settings keeps the saved segment.
+- Agent can pick up the new config without restart.
+- Executors or the check script shows the active task check frequency.
+- Executors can still determine online state through the fixed heartbeat.
+- New tasks are claimed within the selected timing window.
+- Results still write back to `tasks`, `reports`, and failed-task `ai_analyses`.
+
+## Check Status
+
+Local process:
+
+```bash
+launchctl list | grep com.meteortest.local-agent
+```
+
+Local logs:
+
+```bash
+tail -f .meteortest-agent/logs/launchd.out.log
+tail -f .meteortest-agent/logs/launchd.err.log
+```
+
+Combined local process and Supabase status:
+
+```bash
+./scripts/check-local-agent.sh
+```
+
+## Supabase Feedback Loop
+
+After startup, the Agent registers or updates `executors`:
+
+- `name`
+- `type`
+- `status`
+- `capabilities`
+- `last_heartbeat_at`
+
+When it claims a task, it updates `tasks`:
+
+- `status=running`
+- `executor_id`
+- `started_at`
+- final `status=succeeded/failed/timeout`
+- `finished_at`
+
+After execution, it writes `reports`:
+
+- `task_id`
+- `summary`
+- `log_url`
+- `allure_url`
+
+For failed tasks, it also tries to write `ai_analyses`:
+
+- `failure_reason`
+- `impact`
+- `suggestion`
+- `suspected_files`
+- `flaky_probability`
+
+The Web console should be checked in three places:
+
+- Executors: Agent online state and heartbeat.
+- Tasks / Task Detail: queued -> running -> succeeded / failed.
+- Reports / Task Detail: logs, Allure, and AI analysis.
+
+## OpenClaw Usage
+
+OpenClaw should not be the primary process supervisor. Use it for scheduled checks:
+
+```bash
+./scripts/check-local-agent.sh
+```
+
+If needed, have it run:
+
+```bash
+./scripts/restart-local-agent-launchd.sh
+```
+
+Keep `launchd` responsible for process supervision and Supabase responsible for platform feedback.

--- a/docs/local-agent-operations.zh-CN.md
+++ b/docs/local-agent-operations.zh-CN.md
@@ -1,0 +1,196 @@
+# Local Agent 运维方式
+
+更新时间：2026-05-13
+
+Local Agent 的管理要分成本机进程和平台反馈两部分看：
+
+- 本机进程由 macOS `launchd` 常驻。
+- 平台状态以 Supabase 为准。
+- Web 控制台从 Supabase 读取 executor、task、report 和 AI analysis。
+
+## 推荐常驻方式
+
+在 MeteorTest 仓库根目录执行一次：
+
+```bash
+./scripts/install-local-agent-launchd.sh
+```
+
+它会安装用户级 `launchd` 服务：
+
+- 登录 macOS 后自动启动。
+- 进程退出后自动拉起。
+- 启动命令来自 `scripts/start-local-agent.sh`。
+- 环境变量读取 `apps/web/.env.local`。
+- Agent 配置读取 `agent/config.yaml`。
+
+## 平台可调的任务检查频率
+
+目标不是让用户理解轮询、心跳等实现细节，而是提供一个“本机服务器节能模式”：
+
+- 本机 Agent 始终常驻待命。
+- 没任务时减少对 Supabase 的请求。
+- 任务少时可以慢一点检查，节省本机和 Supabase 资源。
+- 需要快速执行时，可以临时调快。
+- 任务结果仍然以 Supabase 为准，Web 页面继续展示任务状态、报告、日志和 AI 分析。
+
+这个设置只控制 Agent **多久检查一次新任务**，不控制在线心跳。
+
+心跳建议固定为 `120s`：
+
+- 心跳只更新 `executors.status` 和 `executors.last_heartbeat_at`，资源开销很小。
+- 心跳过长会让 Web 控制台更难判断 Agent 是否真的在线。
+- 即使任务检查频率设置为 `60min`，Agent 也应该继续用固定心跳告诉平台“我还活着”。
+
+最终策略：
+
+```text
+任务检查频率：由设置页分段滑动条控制，30s 到 60min。
+Agent 在线心跳：固定 120s，不跟随任务检查频率变化。
+```
+
+设置页文案建议：
+
+```text
+任务检查频率
+控制 Local Agent 多久检查一次新任务。频率越低越省资源，但新任务开始执行会更慢。
+```
+
+默认值建议：`5m`。
+
+分段式时间密度：
+
+| 档位 | 显示文案 | 实际值 | 适用场景 |
+| --- | --- | ---: | --- |
+| 1 | 30s | 30 秒 | 正在调试、希望任务尽快开始 |
+| 2 | 1m | 60 秒 | 短时间集中执行任务 |
+| 3 | 5m | 300 秒 | 默认推荐，兼顾响应和资源 |
+| 4 | 10m | 600 秒 | 任务较少，但仍希望较快响应 |
+| 5 | 15m | 900 秒 | 日常低频使用 |
+| 6 | 30min | 1800 秒 | 半天级偶发任务 |
+| 7 | 45min | 2700 秒 | 很低频任务 |
+| 8 | 60min | 3600 秒 | 极低频、省资源优先 |
+
+设置页交互：
+
+- 使用分段式滑动条，而不是自由输入数字。
+- 滑动条只允许选择上表 8 个档位。
+- 当前档位旁显示“约每 X 检查一次新任务”。
+- 下方显示资源提示：更短更快、更长更省资源。
+- 保存后写入 Supabase，Agent 下次读取配置后生效。
+
+数据与权限：
+
+- 配置应作为平台级 Agent 运行配置保存，而不是浏览器本地设置。
+- 只有 `admin` 可以修改。
+- `viewer` / `operator` 可以查看当前策略，但不能修改。
+- 本机 `agent/config.yaml` 只保留启动兜底值；平台配置存在时，以平台配置为准。
+
+建议数据表：
+
+```text
+agent_runtime_settings
+- id
+- executor_name
+- enabled
+- task_check_interval_seconds
+- task_source
+- private_preview_only
+- updated_by
+- updated_at
+```
+
+执行策略：
+
+- Agent 启动后先读取平台配置。
+- Agent 空闲时按 `task_check_interval_seconds` 等待下一次检查。
+- Agent 在线心跳保持固定低频，例如 `120s`，不受 `task_check_interval_seconds` 影响。
+- Agent 每隔一段时间重新读取配置，让设置页修改可以自动生效。
+- 如果读取平台配置失败，继续使用本机配置或启动脚本中的默认值。
+- 任务执行中不强行中断；新的时间间隔从下一轮空闲检查开始生效。
+
+验收标准：
+
+- 设置页能通过分段式滑动条选择 `30s / 1m / 5m / 10m / 15m / 30min / 45min / 60min`。
+- 保存后刷新页面仍保持当前档位。
+- Agent 不重启也能在后续周期内读取到新配置。
+- Executors 页面或检查脚本能看到当前生效的任务检查频率。
+- Executors 页面仍能通过固定心跳判断 Agent 在线状态。
+- 新任务会在所选时间范围内被领取。
+- 任务执行结果继续写回 `tasks`、`reports`，失败时继续写回 `ai_analyses`。
+
+## 运行状态怎么看
+
+本机进程状态：
+
+```bash
+launchctl list | grep com.meteortest.local-agent
+```
+
+本机日志：
+
+```bash
+tail -f .meteortest-agent/logs/launchd.out.log
+tail -f .meteortest-agent/logs/launchd.err.log
+```
+
+综合检查本机进程和 Supabase 状态：
+
+```bash
+./scripts/check-local-agent.sh
+```
+
+## Supabase 中的反馈链路
+
+Agent 启动后会注册或更新 `executors`：
+
+- `name`
+- `type`
+- `status`
+- `capabilities`
+- `last_heartbeat_at`
+
+Agent 轮询到任务后会更新 `tasks`：
+
+- `status=running`
+- `executor_id`
+- `started_at`
+- 最终 `status=succeeded/failed/timeout`
+- `finished_at`
+
+任务完成后会写 `reports`：
+
+- `task_id`
+- `summary`
+- `log_url`
+- `allure_url`
+
+任务失败时会尽量写 `ai_analyses`：
+
+- `failure_reason`
+- `impact`
+- `suggestion`
+- `suspected_files`
+- `flaky_probability`
+
+所以 Web 上最终应该看三处：
+
+- Executors 页面：确认 Agent 在线和心跳。
+- Tasks / Task Detail：确认任务从 queued 到 running，再到 succeeded / failed。
+- Reports / Task Detail：确认日志、Allure 和 AI 分析是否写回。
+
+## OpenClaw 怎么用
+
+OpenClaw 不建议作为主守护进程。它更适合做定时巡检：
+
+```bash
+./scripts/check-local-agent.sh
+```
+
+如果发现异常，再定时执行：
+
+```bash
+./scripts/restart-local-agent-launchd.sh
+```
+
+主常驻仍交给 `launchd`，平台反馈仍以 Supabase 为准。

--- a/docs/platform-architecture-roadmap.md
+++ b/docs/platform-architecture-roadmap.md
@@ -69,6 +69,25 @@ The login page accepts either username/password or phone/password:
 5. Run the private Agent and validate with `npm run validate:private-agent-loop`.
 6. Continue with organization/project-level permissions, feedback admin workflow, task cancel/rerun, and richer Allure visualization.
 
+## Agent Resource Saving And Platform Management Plan
+
+Goal: treat the local Agent as a private server, reduce resource usage when task volume is low, and keep task results fully written back to Supabase.
+
+First feature: platform-configurable task check frequency.
+
+- Add “Task check frequency” to Settings.
+- Use a segmented slider, not free numeric input.
+- Support these segments: `30s`, `1m`, `5m`, `10m`, `15m`, `30min`, `45min`, `60min`.
+- Recommended default: `5m`.
+- Shorter segments start tasks faster; longer segments reduce local and Supabase requests.
+- This setting only affects new-task check frequency. It does not affect Agent online heartbeat.
+- Recommended fixed Agent heartbeat: `120s`, so the Web console can reliably determine executor online state.
+- Save config to Supabase as platform-level Agent runtime configuration, editable by `admin` only.
+- Keep the Agent resident in the background. While idle, it checks for new tasks according to the configured interval. Results still write back to `tasks`, `reports`, and failed-task `ai_analyses`.
+- Local `launchd` is only the process supervisor. Platform config controls runtime strategy. Web surfaces show status and results.
+
+Details: [Local Agent operations](local-agent-operations.md).
+
 ## Account-Scoped Data Plan
 
 Tracking issue: `#82 [Feature] Add account-scoped preferences and AI conversation history`

--- a/docs/platform-architecture-roadmap.zh-CN.md
+++ b/docs/platform-architecture-roadmap.zh-CN.md
@@ -87,6 +87,25 @@ MeteorTest 当前已经是早期 Beta 形态的通用自动化测试平台。它
 5. 在私有机器运行 Local Agent，再运行 `npm run validate:private-agent-loop` 验证闭环。
 6. 下一轮推进团队/组织模型、项目级权限、反馈管理后台、任务取消/重跑、报告产物可视化。
 
+## Agent 资源节省与平台化管理计划
+
+目标：把本机 Local Agent 当作一台私有服务器来管理，在任务量不高时减少资源占用，同时保持任务结果完整回写 Supabase。
+
+第一轮功能：平台可调的任务检查频率。
+
+- 设置页新增“任务检查频率”。
+- 使用分段式滑动条，不提供自由数字输入。
+- 支持档位：`30s`、`1m`、`5m`、`10m`、`15m`、`30min`、`45min`、`60min`。
+- 默认档位建议为 `5m`。
+- 档位越短，新任务开始更快；档位越长，本机和 Supabase 请求更少。
+- 该设置只影响新任务检查频率，不影响 Agent 在线心跳。
+- Agent 在线心跳固定建议为 `120s`，用于保持 Web 控制台对执行器在线状态的判断。
+- 配置写入 Supabase 平台级 Agent 运行配置，只有 `admin` 可以修改。
+- Agent 后台常驻，空闲时按配置间隔检查新任务；任务执行结果仍写回 `tasks`、`reports` 和失败任务 `ai_analyses`。
+- 本机 `launchd` 只负责进程常驻；平台配置负责运行策略；Web 页面负责展示状态和结果。
+
+详细方案见 [Local Agent 运维方式](local-agent-operations.zh-CN.md)。
+
 ## 账号级数据推进计划
 
 跟踪 issue：`#82 [Feature] Add account-scoped preferences and AI conversation history`

--- a/scripts/check-local-agent.sh
+++ b/scripts/check-local-agent.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+LABEL="com.meteortest.local-agent"
+
+if [ -f "apps/web/.env.local" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "apps/web/.env.local"
+  set +a
+fi
+
+export SUPABASE_URL="${SUPABASE_URL:-${NEXT_PUBLIC_SUPABASE_URL:-}}"
+
+AGENT_NAME="$(
+  agent/.venv/bin/python - <<'PY' 2>/dev/null || printf 'local-mac-01'
+import yaml
+from pathlib import Path
+config = yaml.safe_load(Path("agent/config.yaml").read_text(encoding="utf-8"))
+print(config.get("agent", {}).get("name") or "local-mac-01")
+PY
+)"
+
+echo "Local process supervisor:"
+if launchctl list | grep -q "$LABEL"; then
+  launchctl list | grep "$LABEL"
+else
+  echo "  ${LABEL} is not loaded"
+fi
+
+echo
+echo "Local logs:"
+echo "  .meteortest-agent/logs/launchd.out.log"
+echo "  .meteortest-agent/logs/launchd.err.log"
+
+if [ -z "${SUPABASE_URL}" ] || [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+  echo
+  echo "Supabase status: skipped. SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is missing."
+  exit 0
+fi
+
+AUTH_HEADERS=(
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}"
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
+)
+
+echo
+echo "Supabase executor row:"
+curl -fsS "${SUPABASE_URL}/rest/v1/executors?name=eq.${AGENT_NAME}&select=id,name,type,status,last_heartbeat_at" "${AUTH_HEADERS[@]}"
+
+echo
+echo
+echo "Recent tasks claimed by ${AGENT_NAME}:"
+EXECUTOR_ID="$(
+  curl -fsS "${SUPABASE_URL}/rest/v1/executors?name=eq.${AGENT_NAME}&select=id&limit=1" "${AUTH_HEADERS[@]}" \
+    | agent/.venv/bin/python -c 'import json,sys; rows=json.load(sys.stdin); print(rows[0]["id"] if rows else "")'
+)"
+
+if [ -z "$EXECUTOR_ID" ]; then
+  echo "[]"
+  exit 0
+fi
+
+curl -fsS "${SUPABASE_URL}/rest/v1/tasks?executor_id=eq.${EXECUTOR_ID}&select=id,status,environment,started_at,finished_at,created_at&order=created_at.desc&limit=5" "${AUTH_HEADERS[@]}"
+
+echo

--- a/scripts/install-local-agent-launchd.sh
+++ b/scripts/install-local-agent-launchd.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="com.meteortest.local-agent"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="$ROOT_DIR/.meteortest-agent/logs"
+
+mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+
+cat > "$PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${ROOT_DIR}/scripts/start-local-agent.sh</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${ROOT_DIR}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${LOG_DIR}/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_DIR}/launchd.err.log</string>
+</dict>
+</plist>
+PLIST
+
+launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
+launchctl load "$PLIST_PATH"
+
+echo "Installed ${LABEL}"
+echo "Plist: ${PLIST_PATH}"
+echo "Logs: ${LOG_DIR}/launchd.out.log and ${LOG_DIR}/launchd.err.log"
+echo "Status: launchctl list | grep ${LABEL}"

--- a/scripts/restart-local-agent-launchd.sh
+++ b/scripts/restart-local-agent-launchd.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LABEL="com.meteortest.local-agent"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+if [ ! -f "$PLIST_PATH" ]; then
+  echo "Missing ${PLIST_PATH}. Run ./scripts/install-local-agent-launchd.sh first." >&2
+  exit 1
+fi
+
+launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
+launchctl load "$PLIST_PATH"
+
+echo "Restarted ${LABEL}"

--- a/scripts/start-local-agent.sh
+++ b/scripts/start-local-agent.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ -f "apps/web/.env.local" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "apps/web/.env.local"
+  set +a
+fi
+
+export SUPABASE_URL="${SUPABASE_URL:-${NEXT_PUBLIC_SUPABASE_URL:-}}"
+export SUPABASE_ARTIFACT_BUCKET="${SUPABASE_ARTIFACT_BUCKET:-test-artifacts}"
+export METEORTEST_AGENT_TASK_SOURCE="${METEORTEST_AGENT_TASK_SOURCE:-web-console}"
+export METEORTEST_AGENT_PRIVATE_PREVIEW_ONLY="${METEORTEST_AGENT_PRIVATE_PREVIEW_ONLY:-1}"
+
+PYTHON_BIN="${METEORTEST_AGENT_PYTHON:-agent/.venv/bin/python}"
+INTERVAL="${METEORTEST_AGENT_INTERVAL:-10}"
+
+if [ ! -f "agent/config.yaml" ]; then
+  echo "Missing agent/config.yaml. Copy agent/config.example.yaml to agent/config.yaml and update repository paths." >&2
+  exit 1
+fi
+
+if [ -z "${SUPABASE_URL}" ]; then
+  echo "Missing SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL. Add it to apps/web/.env.local." >&2
+  exit 1
+fi
+
+if [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+  echo "Missing SUPABASE_SERVICE_ROLE_KEY. Add it to apps/web/.env.local or export it before starting." >&2
+  exit 1
+fi
+
+if [ ! -x "$PYTHON_BIN" ]; then
+  echo "Missing $PYTHON_BIN. Create the Agent virtualenv first:" >&2
+  echo "  python3 -m venv agent/.venv" >&2
+  echo "  agent/.venv/bin/python -m pip install -r agent/requirements.txt" >&2
+  exit 1
+fi
+
+echo "Starting MeteorTest Local Agent with interval=${INTERVAL}s"
+echo "Task filters: source=${METEORTEST_AGENT_TASK_SOURCE}, private_preview_only=${METEORTEST_AGENT_PRIVATE_PREVIEW_ONLY}"
+exec "$PYTHON_BIN" -m agent.agent --config agent/config.yaml --interval "$INTERVAL"

--- a/scripts/uninstall-local-agent-launchd.sh
+++ b/scripts/uninstall-local-agent-launchd.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LABEL="com.meteortest.local-agent"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
+rm -f "$PLIST_PATH"
+
+echo "Uninstalled ${LABEL}"


### PR DESCRIPTION
## Summary
- Add Local Agent operations documentation for process supervision and Supabase-backed feedback.
- Add local scripts for starting, installing, restarting, uninstalling, and checking the Agent.
- Document the segmented task check frequency plan and fixed 120s heartbeat decision.

## Proposed Changes
- Add macOS launchd helper scripts for keeping Local Agent resident.
- Add a combined check script that reports local supervisor status and Supabase executor/task feedback.
- Add English and Chinese Local Agent operations docs.
- Update README and roadmap docs with the Agent resource-saving strategy.

## Test Plan
- bash -n scripts/start-local-agent.sh scripts/install-local-agent-launchd.sh scripts/uninstall-local-agent-launchd.sh scripts/restart-local-agent-launchd.sh scripts/check-local-agent.sh

Closes #87