### PR TITLE
[Bug] Fix Settings task check frequency resets to default on page reload

### DIFF
--- a/apps/web/app/settings/SettingsPage.tsx
+++ b/apps/web/app/settings/SettingsPage.tsx
@@ -202,11 +202,16 @@ export default function SettingsPage() {
 
     async function loadPreferences() {
       try {
-        const res = await fetch('/api/preferences', { cache: 'no-store' })
-        if (!res.ok) return
-        const data = await res.json() as { preferences?: Partial<AccountPreferences> }
-        if (cancelled || !data.preferences) return
-        const merged = normalizeSettings({ ...settings, ...data.preferences })
+        const [prefRes, runtimeRes] = await Promise.all([
+          fetch('/api/preferences', { cache: 'no-store' }),
+          fetch('/api/agent/runtime-settings', { cache: 'no-store' }),
+        ])
+        if (cancelled) return
+        const prefData = prefRes.ok ? await prefRes.json() as { preferences?: Partial<AccountPreferences> } : {}
+        const runtimeData = runtimeRes.ok ? await runtimeRes.json() as { task_check_interval_seconds?: number } : {}
+        const extra: Partial<Settings> = {}
+        if (runtimeData.task_check_interval_seconds) extra.taskCheckIntervalSeconds = runtimeData.task_check_interval_seconds
+        const merged = normalizeSettings({ ...settings, ...(prefData.preferences ?? {}), ...extra })
         window.localStorage.setItem(preferenceStorageKey, JSON.stringify(merged))
         applyTheme(merged.theme)
         setSettings(merged)


### PR DESCRIPTION
## Summary

Fix Settings page not restoring saved task check frequency on reload. The page now fetches task_check_interval_seconds from /api/agent/runtime-settings in parallel with account preferences on init.

## Test Plan

- Change task check frequency slider to any non-default value and save
- Reload the Settings page
- Confirm the slider shows the previously saved value

Closes #93
