### PR TITLE
[Feature] Keep Local Agent awake on macOS

### DIFF
--- a/docs/local-agent-operations.md
+++ b/docs/local-agent-operations.md
@@ -23,6 +23,21 @@ This installs a user-level `launchd` service:
 - Uses `scripts/start-local-agent.sh`.
 - Reads environment variables from `apps/web/.env.local`.
 - Reads Agent configuration from `agent/config.yaml`.
+- On macOS, runs through `caffeinate -dimsu` by default so lock-screen sleep does not pause the Agent.
+
+Note: `launchd` keeps the process resident, while `caffeinate` prevents system sleep. Locking the screen does not stop the Agent by itself; the Agent pauses when the Mac enters sleep. The default startup keeps the machine awake while allowing the display to sleep.
+
+To disable this sleep-prevention behavior, set:
+
+```bash
+export METEORTEST_AGENT_CAFFEINATE=0
+```
+
+After changing the script or environment, restart the service:
+
+```bash
+./scripts/restart-local-agent-launchd.sh
+```
 
 ## Platform-Configurable Task Check Frequency
 

--- a/docs/local-agent-operations.zh-CN.md
+++ b/docs/local-agent-operations.zh-CN.md
@@ -23,6 +23,21 @@ Local Agent 的管理要分成本机进程和平台反馈两部分看：
 - 启动命令来自 `scripts/start-local-agent.sh`。
 - 环境变量读取 `apps/web/.env.local`。
 - Agent 配置读取 `agent/config.yaml`。
+- macOS 上默认通过 `caffeinate -dimsu` 运行，防止锁屏后系统睡眠导致 Agent 暂停。
+
+注意：`launchd` 负责进程常驻，`caffeinate` 负责防止系统睡眠。锁屏本身不会停止 Agent；真正会暂停 Agent 的是 Mac 进入 sleep。默认配置会尽量保持机器唤醒，只关闭屏幕不影响 Agent。
+
+如果你确实希望关闭这个防睡眠行为，可以在启动环境中设置：
+
+```bash
+export METEORTEST_AGENT_CAFFEINATE=0
+```
+
+修改脚本或环境变量后，需要重新安装或重启服务才会生效：
+
+```bash
+./scripts/restart-local-agent-launchd.sh
+```
 
 ## 平台可调的任务检查频率
 

--- a/scripts/start-local-agent.sh
+++ b/scripts/start-local-agent.sh
@@ -43,4 +43,12 @@ fi
 
 echo "Starting MeteorTest Local Agent with interval=${INTERVAL}s"
 echo "Task filters: source=${METEORTEST_AGENT_TASK_SOURCE}, private_preview_only=${METEORTEST_AGENT_PRIVATE_PREVIEW_ONLY}"
-exec "$PYTHON_BIN" -m agent.agent --config agent/config.yaml --interval "$INTERVAL"
+
+AGENT_CMD=("$PYTHON_BIN" -m agent.agent --config agent/config.yaml --interval "$INTERVAL")
+
+if [ "${METEORTEST_AGENT_CAFFEINATE:-1}" = "1" ] && command -v caffeinate >/dev/null 2>&1; then
+  echo "Using caffeinate to keep macOS awake while Local Agent is running"
+  exec caffeinate -dimsu "${AGENT_CMD[@]}"
+fi
+
+exec "${AGENT_CMD[@]}"


### PR DESCRIPTION
## Summary

- Wrap the Local Agent startup command with macOS caffeinate by default.
- Add an opt-out environment variable for operators who do not want sleep prevention.
- Update Local Agent operations docs in English and Chinese.

## Validation

- bash -n scripts/start-local-agent.sh scripts/install-local-agent-launchd.sh scripts/restart-local-agent-launchd.sh

Closes #96