### PR TITLE
[Bug] Polish AI response formatting and stabilize Local Agent scripts

### DIFF
--- a/apps/web/app/ai/AiPage.tsx
+++ b/apps/web/app/ai/AiPage.tsx
@@ -314,6 +314,22 @@ function stripInlineMarkup(text: string) {
     .trim()
 }
 
+function stripBlockDecorators(text: string) {
+  return stripInlineMarkup(text)
+    .replace(/^\s*(?:-{3,}|_{3,}|\*{3,})\s*/, '')
+    .replace(/^\s{0,3}#{1,6}\s*/, '')
+    .replace(/^[\s\p{Extended_Pictographic}\uFE0F]+/u, '')
+    .trim()
+}
+
+function localizedStatusHeading(text: string, t: Dictionary) {
+  const clean = stripBlockDecorators(text)
+  return clean.replace(/^(queued|running|succeeded|failed|cancelled|timeout)\b/i, status => {
+    const key = status.toLowerCase() as keyof typeof t.status
+    return t.status[key] ?? status
+  })
+}
+
 function renderInlineText(text: string, t: Dictionary) {
   return renderTaskLinks(stripInlineMarkup(sanitizeVisibleText(text, t)))
 }
@@ -663,6 +679,14 @@ function MessageContent({ content, hasActions, t }: { content: string; hasAction
   let index = 0
 
   while (index < lines.length) {
+    const currentLine = lines[index] ?? ''
+    const cleanCurrentLine = stripBlockDecorators(currentLine)
+
+    if (!cleanCurrentLine && /^\s*(?:-{3,}|_{3,}|\*{3,})\s*$/.test(currentLine)) {
+      index += 1
+      continue
+    }
+
     if (lines[index]?.includes('|') && isTableSeparator(lines[index + 1] ?? '')) {
       const headers = splitTableRow(lines[index])
       index += 2
@@ -715,10 +739,17 @@ function MessageContent({ content, hasActions, t }: { content: string; hasAction
       continue
     }
 
-    if (/^\s*\*\*[^*]+\*\*\s*:?\s*$/.test(lines[index] ?? '')) {
+    if (/^\s*(?:-{3,}\s*)?(?:#{1,6}\s*)?(?:[\p{Extended_Pictographic}\uFE0F]\s*)?\*\*[^*]+\*\*\s*:?\s*$/u.test(currentLine)
+      || /^\s*(?:-{3,}\s*)?#{1,6}\s+/.test(currentLine)
+    ) {
+      const heading = localizedStatusHeading(currentLine, t)
+      if (!heading) {
+        index += 1
+        continue
+      }
       nodes.push(
         <div key={`heading-${index}`} className="pt-1 text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-          {renderInlineText(lines[index], t)}
+          {renderInlineText(heading, t)}
         </div>
       )
       index += 1
@@ -730,9 +761,11 @@ function MessageContent({ content, hasActions, t }: { content: string; hasAction
       index < lines.length
       && !(lines[index]?.includes('|') && isTableSeparator(lines[index + 1] ?? ''))
       && !/^\s*[-*]\s+/.test(lines[index] ?? '')
-      && !/^\s*\*\*[^*]+\*\*\s*:?\s*$/.test(lines[index] ?? '')
+      && !/^\s*(?:-{3,}\s*)?(?:#{1,6}\s*)?(?:[\p{Extended_Pictographic}\uFE0F]\s*)?\*\*[^*]+\*\*\s*:?\s*$/u.test(lines[index] ?? '')
+      && !/^\s*(?:-{3,}\s*)?#{1,6}\s+/.test(lines[index] ?? '')
     ) {
-      paragraph.push(lines[index])
+      const cleanLine = stripBlockDecorators(lines[index] ?? '')
+      if (cleanLine) paragraph.push(cleanLine)
       index += 1
     }
     const text = paragraph.join('\n').trim()

--- a/apps/web/content/i18n.ts
+++ b/apps/web/content/i18n.ts
@@ -645,7 +645,8 @@ export const dictionaries = {
 3. 用户询问任务状态、运行结果、报告或分析且给出任务显示 ID 时，调用 get_task_detail。
 4. 工具执行成功后，明确给出创建结果和下一步入口。
 5. 信息不足时先追问，不要猜测关键字段。
-6. 最近平台快照如下，必要时可再调用 get_platform_snapshot 获取更完整数据：
+6. 不要使用 markdown 标题、分隔线或 emoji。需要分组时使用简短小标题、表格或自然段。
+7. 最近平台快照如下，必要时可再调用 get_platform_snapshot 获取更完整数据：
 ${snapshot}`,
     },
   },
@@ -1285,7 +1286,8 @@ Rules:
 3. When the user asks about task status, results, reports, or analysis and provides a task display ID, call get_task_detail.
 4. After a tool succeeds, clearly state the result and next entry point.
 5. If required information is missing, ask a follow-up question instead of guessing key fields.
-6. The latest platform snapshot is below. Call get_platform_snapshot when fuller data is needed:
+6. Do not use markdown headings, separators, or emoji. Use concise section labels, tables, or paragraphs when grouping information.
+7. The latest platform snapshot is below. Call get_platform_snapshot when fuller data is needed:
 ${snapshot}`,
     },
   },

--- a/scripts/check-local-agent.sh
+++ b/scripts/check-local-agent.sh
@@ -25,8 +25,8 @@ PY
 )"
 
 echo "Local process supervisor:"
-if launchctl list | grep -q "$LABEL"; then
-  launchctl list | grep "$LABEL"
+if launchctl print "gui/$(id -u)/${LABEL}" >/dev/null 2>&1; then
+  launchctl print "gui/$(id -u)/${LABEL}" | sed -n '1,12p'
 else
   echo "  ${LABEL} is not loaded"
 fi

--- a/scripts/install-local-agent-launchd.sh
+++ b/scripts/install-local-agent-launchd.sh
@@ -33,10 +33,12 @@ cat > "$PLIST_PATH" <<PLIST
 </plist>
 PLIST
 
-launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
-launchctl load "$PLIST_PATH"
+launchctl bootout "gui/$(id -u)" "$PLIST_PATH" >/dev/null 2>&1 || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+launchctl enable "gui/$(id -u)/${LABEL}" >/dev/null 2>&1 || true
+launchctl kickstart -k "gui/$(id -u)/${LABEL}"
 
 echo "Installed ${LABEL}"
 echo "Plist: ${PLIST_PATH}"
 echo "Logs: ${LOG_DIR}/launchd.out.log and ${LOG_DIR}/launchd.err.log"
-echo "Status: launchctl list | grep ${LABEL}"
+echo "Status: launchctl print gui/$(id -u)/${LABEL}"

--- a/scripts/restart-local-agent-launchd.sh
+++ b/scripts/restart-local-agent-launchd.sh
@@ -9,7 +9,9 @@ if [ ! -f "$PLIST_PATH" ]; then
   exit 1
 fi
 
-launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
-launchctl load "$PLIST_PATH"
+launchctl bootout "gui/$(id -u)" "$PLIST_PATH" >/dev/null 2>&1 || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+launchctl enable "gui/$(id -u)/${LABEL}" >/dev/null 2>&1 || true
+launchctl kickstart -k "gui/$(id -u)/${LABEL}"
 
 echo "Restarted ${LABEL}"

--- a/scripts/uninstall-local-agent-launchd.sh
+++ b/scripts/uninstall-local-agent-launchd.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 LABEL="com.meteortest.local-agent"
 PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
 
-launchctl unload "$PLIST_PATH" >/dev/null 2>&1 || true
+launchctl bootout "gui/$(id -u)" "$PLIST_PATH" >/dev/null 2>&1 || true
 rm -f "$PLIST_PATH"
 
 echo "Uninstalled ${LABEL}"


### PR DESCRIPTION
## Summary
Fix rough AI Center response rendering and make Local Agent launchd helper scripts use the modern launchd management path.

## Proposed Changes
- Sanitize AI message rendering for raw markdown separators, heading markers, emoji prefixes, and localized status headings.
- Update Chinese and English AI system prompts so future replies avoid markdown headings, separators, and emoji.
- Replace launchd load/unload usage with bootout/bootstrap/enable/kickstart in install, restart, and uninstall scripts.
- Update the Local Agent check script to inspect the user launchd domain with launchctl print, matching the status alias behavior.

## Test Plan
- npm run lint in apps/web
- bash -n scripts/check-local-agent.sh scripts/install-local-agent-launchd.sh scripts/restart-local-agent-launchd.sh scripts/uninstall-local-agent-launchd.sh
- ./scripts/check-local-agent.sh confirms the launchd service reports state = running before Supabase DNS lookup

Closes #104