### PR TITLE
[Feature] Add release deployment track

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - release
   push:
     branches:
       - main
+      - release
       - "dev/v-peq/**"
 
 jobs:

--- a/.github/workflows/deploy-tencent.yml
+++ b/.github/workflows/deploy-tencent.yml
@@ -1,0 +1,75 @@
+name: Deploy Tencent
+
+on:
+  push:
+    branches:
+      - main
+      - release
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-tencent-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Web
+    runs-on: [self-hosted, linux, x64, tencent, meteortest]
+    environment: tencent
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve target
+        id: target
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_NAME}" = "release" ]; then
+            echo "app_dir=/srv/meteortest-release" >> "$GITHUB_OUTPUT"
+            echo "pm2_name=meteortest-release" >> "$GITHUB_OUTPUT"
+            echo "port=3300" >> "$GITHUB_OUTPUT"
+          else
+            echo "app_dir=/srv/meteortest" >> "$GITHUB_OUTPUT"
+            echo "pm2_name=meteortest-web" >> "$GITHUB_OUTPUT"
+            echo "port=3301" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy
+        shell: bash
+        run: |
+          retry() {
+            local attempts="$1"
+            local delay="$2"
+            shift 2
+
+            local attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge "$attempts" ]; then
+                return 1
+              fi
+
+              echo "Command failed. Retrying in ${delay}s (${attempt}/${attempts})..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          mkdir -p '${{ steps.target.outputs.app_dir }}'
+          rsync -a --delete \
+            --exclude '.git' \
+            --exclude 'apps/web/.next' \
+            --exclude 'apps/web/node_modules' \
+            ./ '${{ steps.target.outputs.app_dir }}/'
+
+          cd '${{ steps.target.outputs.app_dir }}/apps/web'
+          retry 3 15 npm ci
+          set -a
+          . /etc/meteortest/meteortest-web.env
+          set +a
+          retry 2 15 npm run build
+
+          pm2 delete '${{ steps.target.outputs.pm2_name }}' || true
+          unset RUNNER_TRACKING_ID
+          pm2 start npm --name '${{ steps.target.outputs.pm2_name }}' -- run start -- --hostname 127.0.0.1 --port '${{ steps.target.outputs.port }}'
+          pm2 save
+          retry 12 5 curl -fsS 'http://127.0.0.1:${{ steps.target.outputs.port }}/' >/dev/null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,14 @@ git pull origin main
 git switch -c dev/v-peq/changeName
 ```
 
+Release policy:
+
+- `main` is the integration and Tencent preview deployment branch.
+- `release` is the Tencent production deployment branch.
+- Keep feature work flowing into `main` first, then promote `main` to `release` through a PR after validation.
+- Do not cherry-pick selectively into `release` unless the user explicitly requests an emergency hotfix; sync any hotfix back to `main`.
+- Tencent deployment mapping is documented in `docs/tencent-release-deployment.md`.
+
 Branch names should use:
 
 ```text

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -12,6 +12,7 @@
 - Supabase 执行手册：`docs/supabase-account-data-runbook.zh-CN.md`
 - Local Agent 运维：`docs/local-agent-operations.zh-CN.md`
 - 公网预览部署：`docs/vercel-public-preview.zh-CN.md`
+- 腾讯云 Release 部署：`docs/tencent-release-deployment.zh-CN.md`
 - 私有 Agent 闭环验证：`docs/private-agent-preview-loop.zh-CN.md`
 - 内部 ID / DTO 边界：`docs/internal-id-exposure-hardening.zh-CN.md`
 
@@ -30,6 +31,13 @@ MeteorTest 当前是早期 Beta 形态的通用自动化测试平台，已经跑
 
 公网 Web 预览地址：`https://meteortest.jcmeteor.com/`
 
+腾讯云部署已拆分为 main 预发和 release 生产：
+
+```text
+main    -> mt-pre.jcmeteor.com
+release -> meteortest.jcmeteor.com
+```
+
 公网 Web 只作为控制台入口；Local Agent 继续在私有机器或可信 runner 上主动轮询后端，不暴露到公网。
 
 ## 已完成能力
@@ -44,6 +52,7 @@ MeteorTest 当前是早期 Beta 形态的通用自动化测试平台，已经跑
 - 账号级数据：用户偏好、AI 会话历史、平台级 webhook 通知配置。
 - 安全边界：public preview 禁止公网启动本机 Agent；浏览器侧逐步使用 DTO 和公开引用，避免暴露内部 UUID。
 - Web 体验：多语言、主题、响应式基础布局、设置页、执行器页和本地预览脚本。
+- 发布体系：`release` 分支、`Protect release` ruleset、`v0.1.0` 初始发布基线、腾讯云 self-hosted runner 和 main/release 自动部署入口。
 
 ## 当前主线
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ MeteorTest Web needs a host that can run Next.js server routes. GitHub Pages is 
 
 Public preview deployment steps live in `docs/vercel-public-preview.md`. Public Web plus private Agent validation lives in `docs/private-agent-preview-loop.md`.
 
+## Tencent Release Deployment
+
+Tencent deployment uses `main` for preview and `release` for production:
+
+```text
+main    -> mt-pre.jcmeteor.com
+release -> meteortest.jcmeteor.com
+```
+
+The detailed runner, branch, ruleset, environment, and port mapping lives in `docs/tencent-release-deployment.md`.
+
 ## Recommended Validation Flow
 
 1. Run Supabase migrations.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -242,6 +242,17 @@ MeteorTest Web 需要能运行 Next.js 服务端路由的托管平台。GitHub P
 
 公网预览部署步骤统一见 `docs/vercel-public-preview.zh-CN.md`。公网 Web + 私有 Agent 的联通验证统一见 `docs/private-agent-preview-loop.zh-CN.md`。
 
+## 腾讯云 Release 部署
+
+腾讯云部署使用 `main` 作为预发分支，`release` 作为生产分支：
+
+```text
+main    -> mt-pre.jcmeteor.com
+release -> meteortest.jcmeteor.com
+```
+
+runner、分支、ruleset、环境变量和端口映射详见 `docs/tencent-release-deployment.zh-CN.md`。
+
 ## 推荐验证流程
 
 1. 执行 Supabase 迁移。

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ This is the single entry point for MeteorTest documentation. Start here for new 
 | Supabase runbook | `supabase-account-data-runbook.md` / `supabase-account-data-runbook.zh-CN.md` | Auth/RLS, preferences, AI history, display refs SQL execution and verification. |
 | Local Agent operations | `local-agent-operations.md` / `local-agent-operations.zh-CN.md` | Agent daemon, check interval, heartbeat, logs, OpenClaw checks. |
 | Public preview deployment | `vercel-public-preview.md` / `vercel-public-preview.zh-CN.md` | Vercel public preview deployment and safety checks. |
+| Tencent release deployment | `tencent-release-deployment.md` / `tencent-release-deployment.zh-CN.md` | Tencent main/release deployment, runner, branch, and port mapping. |
 | Private Agent loop | `private-agent-preview-loop.md` / `private-agent-preview-loop.zh-CN.md` | Validation flow for public Web plus private Agent execution. |
 | Data exposure boundary | `internal-id-exposure-hardening.md` / `internal-id-exposure-hardening.zh-CN.md` | Internal UUIDs, public refs, DTO/View Model rules. |
 | UI validation | `webui-visual-checklist.md` / `webui-visual-checklist.zh-CN.md` | Theme, layout, responsive, screenshot checklist. |

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -23,6 +23,7 @@
 | Supabase 手册 | `supabase-account-data-runbook.zh-CN.md` / `supabase-account-data-runbook.md` | Auth/RLS、账号偏好、AI 历史、display refs 的 SQL 执行与验证。 |
 | Local Agent 运维 | `local-agent-operations.zh-CN.md` / `local-agent-operations.md` | Agent 常驻、检查频率、心跳、日志、OpenClaw 巡检。 |
 | 公网预览部署 | `vercel-public-preview.zh-CN.md` / `vercel-public-preview.md` | Vercel 公网预览部署和安全检查。 |
+| 腾讯云 Release 部署 | `tencent-release-deployment.zh-CN.md` / `tencent-release-deployment.md` | 腾讯云 main/release 部署、runner、分支和端口映射。 |
 | 私有 Agent 闭环 | `private-agent-preview-loop.zh-CN.md` / `private-agent-preview-loop.md` | 私有 Agent 连接公网 Web 后端的验证流程。 |
 | 数据暴露边界 | `internal-id-exposure-hardening.zh-CN.md` / `internal-id-exposure-hardening.md` | 内部 UUID、公开引用、DTO/View Model 规则。 |
 | UI 验收 | `webui-visual-checklist.zh-CN.md` / `webui-visual-checklist.md` | WebUI 主题、布局、响应式和截图验收清单。 |

--- a/docs/tencent-release-deployment.md
+++ b/docs/tencent-release-deployment.md
@@ -1,0 +1,64 @@
+# Tencent Release Deployment
+
+MeteorTest uses two server-side Tencent deployments:
+
+```text
+release branch -> /srv/meteortest-release -> 127.0.0.1:3300 -> meteortest.jcmeteor.com / mt-cn.jcmeteor.com
+main branch    -> /srv/meteortest         -> 127.0.0.1:3301 -> mt-pre.jcmeteor.com / mt-pre-cn.jcmeteor.com
+```
+
+The public Nginx entry point is port `80`. App ports are bound to `127.0.0.1` only and must not be opened in the Tencent security group.
+
+## GitHub Setup
+
+- Branches:
+  - `main`: integration and preview deployment branch.
+  - `release`: production release branch.
+- Rulesets:
+  - `Protect main`: existing main protection.
+  - `Protect release`: requires the `CI` status check and prevents deletion/non-fast-forward updates.
+- Runner:
+  - Repository runner: `tencent-meteortest`
+  - Labels: `self-hosted`, `linux`, `x64`, `tencent`, `meteortest`
+- Workflow:
+  - `.github/workflows/ci.yml`: validates `main`, `release`, and `dev/v-peq/**`.
+  - `.github/workflows/deploy-tencent.yml`: deploys `main` and `release`.
+
+## Server Environment
+
+Runtime environment variables live on the Tencent server:
+
+```text
+/etc/meteortest/meteortest-web.env
+```
+
+Do not commit real values. The deploy workflow sources this file before building and starting the Next.js app.
+
+## Release Flow
+
+1. Merge feature work into `main`.
+2. Let `main` deploy to the preview endpoint:
+   ```text
+   mt-pre.jcmeteor.com
+   mt-pre-cn.jcmeteor.com
+   ```
+3. Open a PR from `main` into `release`.
+4. Wait for `CI`.
+5. Merge into `release`.
+6. The Tencent deploy workflow updates:
+   ```text
+   /srv/meteortest-release
+   meteortest-release
+   127.0.0.1:3300
+   ```
+7. Create a GitHub Release tag from `release`.
+
+## Current Baseline
+
+The first release baseline is:
+
+```text
+v0.1.0
+```
+
+It marks the initial release branch baseline before the dedicated production deployment diverges from main.

--- a/docs/tencent-release-deployment.zh-CN.md
+++ b/docs/tencent-release-deployment.zh-CN.md
@@ -1,0 +1,64 @@
+# 腾讯云 Release 部署
+
+MeteorTest 在腾讯云上使用两套服务端部署：
+
+```text
+release 分支 -> /srv/meteortest-release -> 127.0.0.1:3300 -> meteortest.jcmeteor.com / mt-cn.jcmeteor.com
+main 分支    -> /srv/meteortest         -> 127.0.0.1:3301 -> mt-pre.jcmeteor.com / mt-pre-cn.jcmeteor.com
+```
+
+公网 Nginx 入口只开放 `80`。应用端口只绑定 `127.0.0.1`，不要在腾讯云安全组中开放。
+
+## GitHub 配置
+
+- 分支：
+  - `main`：集成和预发部署分支。
+  - `release`：生产发布分支。
+- Rulesets：
+  - `Protect main`：已有 main 保护。
+  - `Protect release`：要求 `CI` 状态检查，禁止删除和非快进更新。
+- Runner：
+  - 仓库 runner：`tencent-meteortest`
+  - 标签：`self-hosted`、`linux`、`x64`、`tencent`、`meteortest`
+- Workflow：
+  - `.github/workflows/ci.yml`：验证 `main`、`release` 和 `dev/v-peq/**`。
+  - `.github/workflows/deploy-tencent.yml`：部署 `main` 和 `release`。
+
+## 服务器环境变量
+
+运行时环境变量放在腾讯云服务器：
+
+```text
+/etc/meteortest/meteortest-web.env
+```
+
+不要提交真实值。部署 workflow 会在构建和启动 Next.js 前读取这个文件。
+
+## 发布流程
+
+1. 功能变更先合入 `main`。
+2. `main` 自动部署到预发入口：
+   ```text
+   mt-pre.jcmeteor.com
+   mt-pre-cn.jcmeteor.com
+   ```
+3. 从 `main` 向 `release` 开 PR。
+4. 等待 `CI` 通过。
+5. 合入 `release`。
+6. 腾讯云部署 workflow 更新：
+   ```text
+   /srv/meteortest-release
+   meteortest-release
+   127.0.0.1:3300
+   ```
+7. 从 `release` 创建 GitHub Release tag。
+
+## 当前基线
+
+第一个 release 基线是：
+
+```text
+v0.1.0
+```
+
+它标记 release 分支建立时的初始生产基线。


### PR DESCRIPTION
## Summary
Add a dedicated MeteorTest release deployment track for Tencent-hosted production while keeping main as the preview deployment branch.

## Proposed Changes
- Add Tencent deploy workflow for main and release using the MeteorTest self-hosted runner.
- Extend CI coverage to release pushes and release-targeted PRs.
- Document release branch promotion, runner labels, server env file, and port mappings.
- Record the release policy in AGENTS and project progress docs.

## Test Plan
- npm run lint in apps/web
- Verified GitHub runner tencent-meteortest is online
- Verified Tencent release process starts on 127.0.0.1:3300

Closes #106