### PR TITLE
[Documentation] Update release baseline version

### DIFF
--- a/docs/tencent-release-deployment.md
+++ b/docs/tencent-release-deployment.md
@@ -53,12 +53,20 @@ Do not commit real values. The deploy workflow sources this file before building
    ```
 7. Create a GitHub Release tag from `release`.
 
-## Current Baseline
+## Release Baselines
 
-The first release baseline is:
+The first branch baseline is:
 
 ```text
 v0.1.0
 ```
 
-It marks the initial release branch baseline before the dedicated production deployment diverges from main.
+It marks the initial release branch creation point.
+
+The current Tencent deployment baseline is:
+
+```text
+v0.1.1
+```
+
+It includes the protected release branch, self-hosted Tencent runner deployment, and production/preview split.

--- a/docs/tencent-release-deployment.zh-CN.md
+++ b/docs/tencent-release-deployment.zh-CN.md
@@ -53,12 +53,20 @@ main 分支    -> /srv/meteortest         -> 127.0.0.1:3301 -> mt-pre.jcmeteor.c
    ```
 7. 从 `release` 创建 GitHub Release tag。
 
-## 当前基线
+## Release 基线
 
-第一个 release 基线是：
+第一个分支基线是：
 
 ```text
 v0.1.0
 ```
 
-它标记 release 分支建立时的初始生产基线。
+它标记 release 分支建立时的初始位置。
+
+当前腾讯云部署基线是：
+
+```text
+v0.1.1
+```
+
+它包含受保护的 release 分支、腾讯云 self-hosted runner 部署，以及生产/预发拆分。


### PR DESCRIPTION
## Summary
Update the Tencent release deployment docs to distinguish the first v0.1.0 branch baseline from the current v0.1.1 deployment baseline.

## Proposed Changes
- Keep v0.1.0 documented as the initial release branch creation point.
- Add v0.1.1 as the current Tencent deployment baseline.

## Test Plan
- Documentation-only change; reviewed Markdown diff.

Closes #109