### PR TITLE
[Feature] Align Tencent deploy ports

### DIFF
--- a/.github/workflows/deploy-tencent.yml
+++ b/.github/workflows/deploy-tencent.yml
@@ -30,11 +30,11 @@ jobs:
           if [ "${GITHUB_REF_NAME}" = "release" ]; then
             echo "app_dir=/srv/meteortest-release" >> "$GITHUB_OUTPUT"
             echo "pm2_name=meteortest-release" >> "$GITHUB_OUTPUT"
-            echo "port=3300" >> "$GITHUB_OUTPUT"
+            echo "port=3200" >> "$GITHUB_OUTPUT"
           else
             echo "app_dir=/srv/meteortest" >> "$GITHUB_OUTPUT"
             echo "pm2_name=meteortest-web" >> "$GITHUB_OUTPUT"
-            echo "port=3301" >> "$GITHUB_OUTPUT"
+            echo "port=3201" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Deploy

--- a/docs/tencent-release-deployment.md
+++ b/docs/tencent-release-deployment.md
@@ -3,8 +3,8 @@
 MeteorTest uses two server-side Tencent deployments:
 
 ```text
-release branch -> /srv/meteortest-release -> 127.0.0.1:3300 -> meteortest.jcmeteor.com / mt-cn.jcmeteor.com
-main branch    -> /srv/meteortest         -> 127.0.0.1:3301 -> mt-pre.jcmeteor.com / mt-pre-cn.jcmeteor.com
+release branch -> /srv/meteortest-release -> 127.0.0.1:3200 -> meteortest.jcmeteor.com / mt-cn.jcmeteor.com
+main branch    -> /srv/meteortest         -> 127.0.0.1:3201 -> mt-pre.jcmeteor.com / mt-pre-cn.jcmeteor.com
 ```
 
 The public Nginx entry point is port `80`. App ports are bound to `127.0.0.1` only and must not be opened in the Tencent security group.
@@ -49,7 +49,7 @@ Do not commit real values. The deploy workflow sources this file before building
    ```text
    /srv/meteortest-release
    meteortest-release
-   127.0.0.1:3300
+   127.0.0.1:3200
    ```
 7. Create a GitHub Release tag from `release`.
 

--- a/docs/tencent-release-deployment.zh-CN.md
+++ b/docs/tencent-release-deployment.zh-CN.md
@@ -3,8 +3,8 @@
 MeteorTest 在腾讯云上使用两套服务端部署：
 
 ```text
-release 分支 -> /srv/meteortest-release -> 127.0.0.1:3300 -> meteortest.jcmeteor.com / mt-cn.jcmeteor.com
-main 分支    -> /srv/meteortest         -> 127.0.0.1:3301 -> mt-pre.jcmeteor.com / mt-pre-cn.jcmeteor.com
+release 分支 -> /srv/meteortest-release -> 127.0.0.1:3200 -> meteortest.jcmeteor.com / mt-cn.jcmeteor.com
+main 分支    -> /srv/meteortest         -> 127.0.0.1:3201 -> mt-pre.jcmeteor.com / mt-pre-cn.jcmeteor.com
 ```
 
 公网 Nginx 入口只开放 `80`。应用端口只绑定 `127.0.0.1`，不要在腾讯云安全组中开放。
@@ -49,7 +49,7 @@ main 分支    -> /srv/meteortest         -> 127.0.0.1:3301 -> mt-pre.jcmeteor.c
    ```text
    /srv/meteortest-release
    meteortest-release
-   127.0.0.1:3300
+   127.0.0.1:3200
    ```
 7. 从 `release` 创建 GitHub Release tag。
 


### PR DESCRIPTION
## Summary
Align MeteorTest Tencent deploy workflow and deployment docs with the shared server port plan.

## Proposed Changes
- Use 3200 for release/production deployment.
- Use 3201 for main/pre deployment.
- Update English and Chinese Tencent deployment docs.

## Test Plan
- Verified workflow diff.
- Confirmed Tencent server currently listens on 3200 for MeteorTest release/prod and 3201 for MeteorTest main/pre.

Closes #117