### PR TITLE
[Feature] Prepare v0.1.2 release

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -52,7 +52,7 @@ release -> meteortest.jcmeteor.com
 - 账号级数据：用户偏好、AI 会话历史、平台级 webhook 通知配置。
 - 安全边界：public preview 禁止公网启动本机 Agent；浏览器侧逐步使用 DTO 和公开引用，避免暴露内部 UUID。
 - Web 体验：多语言、主题、响应式基础布局、设置页、执行器页和本地预览脚本。
-- 发布体系：`release` 分支、`Protect release` ruleset、`v0.1.0` 初始发布基线、腾讯云 self-hosted runner 和 main/release 自动部署入口。
+- 发布体系：`release` 分支、`Protect release` ruleset、`v0.1.0` 初始发布基线、`v0.1.2` 腾讯云部署基线、腾讯云 self-hosted runner 和 main/release 自动部署入口。
 
 ## 当前主线
 

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meteortest-web",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meteortest-web",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.105.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteortest-web",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,39 @@
+# Release Notes
+
+Release focus: Tencent release deployment track, security scan fixes, and server port alignment.
+
+## Highlights
+
+- Added the Tencent release deployment track for `main` preview and `release` production.
+- Added release deployment documentation in English and Chinese.
+- Fixed security scan alerts in the Web/API code path and dependency overrides.
+- Aligned Tencent server ports with the shared deployment plan:
+  - `release` / production: `127.0.0.1:3200`
+  - `main` / preview: `127.0.0.1:3201`
+- Updated CI and deployment workflow configuration for the release branch.
+
+## Deployment
+
+Current Tencent deployment mapping:
+
+```text
+release branch -> /srv/meteortest-release -> 127.0.0.1:3200 -> meteortest.jcmeteor.com / mt-cn.jcmeteor.com
+main branch    -> /srv/meteortest         -> 127.0.0.1:3201 -> mt-pre.jcmeteor.com / mt-pre-cn.jcmeteor.com
+```
+
+App ports are bound to `127.0.0.1` only. Public traffic should go through Nginx on HTTPS.
+
+## Versioning
+
+- Web version: `0.1.2`
+- Release tag: `v0.1.2`
+
+## Validation
+
+Before publishing:
+
+```bash
+cd apps/web
+npm run lint
+npm run build
+```

--- a/docs/tencent-release-deployment.md
+++ b/docs/tencent-release-deployment.md
@@ -66,7 +66,7 @@ It marks the initial release branch creation point.
 The current Tencent deployment baseline is:
 
 ```text
-v0.1.1
+v0.1.2
 ```
 
-It includes the protected release branch, self-hosted Tencent runner deployment, and production/preview split.
+It includes the protected release branch, self-hosted Tencent runner deployment, production/preview split, and the `3200/3201` MeteorTest port alignment.

--- a/docs/tencent-release-deployment.zh-CN.md
+++ b/docs/tencent-release-deployment.zh-CN.md
@@ -66,7 +66,7 @@ v0.1.0
 当前腾讯云部署基线是：
 
 ```text
-v0.1.1
+v0.1.2
 ```
 
-它包含受保护的 release 分支、腾讯云 self-hosted runner 部署，以及生产/预发拆分。
+它包含受保护的 release 分支、腾讯云 self-hosted runner 部署、生产/预发拆分，以及 MeteorTest `3200/3201` 端口对齐。


### PR DESCRIPTION
## Summary
Prepare MeteorTest v0.1.2 release metadata, version alignment, and release notes.

## Proposed Changes
- Update Web package and lockfile versions to 0.1.2.
- Add v0.1.2 release notes with a generic Release Notes title.
- Update Tencent deployment baseline docs and progress status.

## Test Plan
- cd apps/web && npm run lint
- cd apps/web && npm run build

Closes #119