### PR TITLE
[Feature] Add release manager workflow

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -1,0 +1,51 @@
+name: Release Manager
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+  checks: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version, for example 0.1.3
+        required: true
+        type: string
+      action:
+        description: Release action
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - prepare
+          - promote
+          - verify
+
+concurrency:
+  group: release-manager
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release Manager
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_MANAGER_TOKEN || github.token }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Run release manager
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_MANAGER_TOKEN || github.token }}
+        run: node scripts/release-manager.mjs "${{ inputs.action }}" --version "${{ inputs.version }}"

--- a/README.md
+++ b/README.md
@@ -253,6 +253,14 @@ release -> meteortest.jcmeteor.com
 
 The detailed runner, branch, ruleset, environment, and port mapping lives in `docs/tencent-release-deployment.md`.
 
+Production publishing is automated by the GitHub Actions `Release Manager` workflow:
+
+```text
+GitHub -> Actions -> Release Manager -> Run workflow
+```
+
+Use `action=full` with a semantic version such as `0.1.3`. The workflow prepares release files, promotes `main` to `release`, waits for Tencent deployment, verifies public URLs, and creates the GitHub Release. Detailed operation and recovery steps live in `docs/release-manager.md`.
+
 ## Recommended Validation Flow
 
 1. Run Supabase migrations.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -253,6 +253,14 @@ release -> meteortest.jcmeteor.com
 
 runner、分支、ruleset、环境变量和端口映射详见 `docs/tencent-release-deployment.zh-CN.md`。
 
+生产发布通过 GitHub Actions 的 `Release Manager` workflow 自动化：
+
+```text
+GitHub -> Actions -> Release Manager -> Run workflow
+```
+
+选择 `action=full`，输入类似 `0.1.3` 的语义化版本号。workflow 会准备 release 文件、将 `main` 提升到 `release`、等待腾讯云部署、验证公网 URL，并创建 GitHub Release。详细操作和中断恢复步骤见 `docs/release-manager.md`。
+
 ## 推荐验证流程
 
 1. 执行 Supabase 迁移。

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ This is the single entry point for MeteorTest documentation. Start here for new 
 | Local Agent operations | `local-agent-operations.md` / `local-agent-operations.zh-CN.md` | Agent daemon, check interval, heartbeat, logs, OpenClaw checks. |
 | Public preview deployment | `vercel-public-preview.md` / `vercel-public-preview.zh-CN.md` | Vercel public preview deployment and safety checks. |
 | Tencent release deployment | `tencent-release-deployment.md` / `tencent-release-deployment.zh-CN.md` | Tencent main/release deployment, runner, branch, and port mapping. |
+| Release automation | `release-manager.md` | GitHub Actions release workflow, release PR automation, and recovery commands. |
 | Private Agent loop | `private-agent-preview-loop.md` / `private-agent-preview-loop.zh-CN.md` | Validation flow for public Web plus private Agent execution. |
 | Data exposure boundary | `internal-id-exposure-hardening.md` / `internal-id-exposure-hardening.zh-CN.md` | Internal UUIDs, public refs, DTO/View Model rules. |
 | UI validation | `webui-visual-checklist.md` / `webui-visual-checklist.zh-CN.md` | Theme, layout, responsive, screenshot checklist. |
@@ -37,6 +38,7 @@ This is the single entry point for MeteorTest documentation. Start here for new 
 - Supabase SQL execution: `supabase-account-data-runbook.md`.
 - Agent startup, daemon, or troubleshooting: `local-agent-operations.md`.
 - Public preview deployment: `vercel-public-preview.md`.
+- Production release automation: `release-manager.md`.
 - Public Web plus private Agent validation: `private-agent-preview-loop.md`.
 - UUID exposure or API DTO work: `internal-id-exposure-hardening.md`.
 - UI, responsive, or theme checks: `webui-visual-checklist.md`.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -24,6 +24,7 @@
 | Local Agent 运维 | `local-agent-operations.zh-CN.md` / `local-agent-operations.md` | Agent 常驻、检查频率、心跳、日志、OpenClaw 巡检。 |
 | 公网预览部署 | `vercel-public-preview.zh-CN.md` / `vercel-public-preview.md` | Vercel 公网预览部署和安全检查。 |
 | 腾讯云 Release 部署 | `tencent-release-deployment.zh-CN.md` / `tencent-release-deployment.md` | 腾讯云 main/release 部署、runner、分支和端口映射。 |
+| 发布自动化 | `release-manager.md` | GitHub Actions 发布入口、release PR 自动化和中断恢复命令。 |
 | 私有 Agent 闭环 | `private-agent-preview-loop.zh-CN.md` / `private-agent-preview-loop.md` | 私有 Agent 连接公网 Web 后端的验证流程。 |
 | 数据暴露边界 | `internal-id-exposure-hardening.zh-CN.md` / `internal-id-exposure-hardening.md` | 内部 UUID、公开引用、DTO/View Model 规则。 |
 | UI 验收 | `webui-visual-checklist.zh-CN.md` / `webui-visual-checklist.md` | WebUI 主题、布局、响应式和截图验收清单。 |
@@ -37,6 +38,7 @@
 - 要执行 Supabase SQL：读 `supabase-account-data-runbook.zh-CN.md`。
 - 要启动、常驻或排查 Agent：读 `local-agent-operations.zh-CN.md`。
 - 要部署公网预览：读 `vercel-public-preview.zh-CN.md`。
+- 要做生产发布：读 `release-manager.md`。
 - 要验证公网 Web + 私有 Agent 闭环：读 `private-agent-preview-loop.zh-CN.md`。
 - 要处理 UUID 暴露或 API DTO：读 `internal-id-exposure-hardening.zh-CN.md`。
 - 要做 UI / 响应式 / 主题检查：读 `webui-visual-checklist.zh-CN.md`。

--- a/docs/release-manager.md
+++ b/docs/release-manager.md
@@ -1,0 +1,50 @@
+# Release Manager
+
+MeteorTest uses `Release Manager` to turn the release flow into one manual GitHub Actions run while keeping the protected branch model.
+
+## Entry Point
+
+Open:
+
+```text
+GitHub -> Actions -> Release Manager -> Run workflow
+```
+
+Inputs:
+
+- `version`: semantic version without the `v` prefix, for example `0.1.3`.
+- `action`:
+  - `full`: prepare version files, promote `main` to `release`, wait for Tencent deployment, verify URLs, and create the GitHub Release.
+  - `prepare`: only create and merge the version/release-note PR into `main`.
+  - `promote`: only create and merge the `main` -> `release` PR, deploy, and create the GitHub Release.
+  - `verify`: only check the production and preview URLs.
+
+## Required Secret
+
+For true one-click releases, configure repository secret `RELEASE_MANAGER_TOKEN` with a fine-grained GitHub token that can read/write contents, issues, pull requests, actions, and releases for this repository.
+
+The workflow falls back to `GITHUB_TOKEN` if the secret is missing, but GitHub may not trigger follow-up CI checks for branches pushed by `GITHUB_TOKEN`. In that fallback mode, use `prepare` and `promote` as recovery steps instead of expecting a fully unattended release.
+
+## What Full Release Does
+
+1. Checks that tag `v<version>` does not already exist.
+2. Creates or reuses a release tracking issue.
+3. Creates a release preparation branch from `origin/main`.
+4. Updates Web package versions and creates `docs/releases/v<version>.md` when needed.
+5. Opens a PR into `main`, waits for checks, and merges it.
+6. Opens a PR from `main` into `release`, waits for checks, and merges it.
+7. Waits for the Tencent release deployment workflow.
+8. Creates GitHub Release `v<version>`.
+9. Verifies the public URLs.
+
+The workflow does not push directly to `main` or `release`.
+
+## Local Recovery
+
+If a run stops after one phase, continue locally or from Actions:
+
+```bash
+node scripts/release-manager.mjs prepare --version 0.1.3
+node scripts/release-manager.mjs promote --version 0.1.3
+node scripts/release-manager.mjs verify --version 0.1.3
+```

--- a/docs/tencent-release-deployment.md
+++ b/docs/tencent-release-deployment.md
@@ -23,6 +23,7 @@ The public Nginx entry point is port `80`. App ports are bound to `127.0.0.1` on
 - Workflow:
   - `.github/workflows/ci.yml`: validates `main`, `release`, and `dev/v-peq/**`.
   - `.github/workflows/deploy-tencent.yml`: deploys `main` and `release`.
+  - `.github/workflows/release-manager.yml`: orchestrates version preparation, release PRs, Tencent deployment verification, and GitHub Release publishing.
 
 ## Server Environment
 
@@ -35,6 +36,10 @@ Runtime environment variables live on the Tencent server:
 Do not commit real values. The deploy workflow sources this file before building and starting the Next.js app.
 
 ## Release Flow
+
+Use `GitHub -> Actions -> Release Manager -> Run workflow` with `action=full` for normal releases. The detailed automation and recovery commands live in `docs/release-manager.md`.
+
+The underlying release flow is:
 
 1. Merge feature work into `main`.
 2. Let `main` deploy to the preview endpoint:

--- a/docs/tencent-release-deployment.zh-CN.md
+++ b/docs/tencent-release-deployment.zh-CN.md
@@ -23,6 +23,7 @@ main 分支    -> /srv/meteortest         -> 127.0.0.1:3201 -> mt-pre.jcmeteor.c
 - Workflow：
   - `.github/workflows/ci.yml`：验证 `main`、`release` 和 `dev/v-peq/**`。
   - `.github/workflows/deploy-tencent.yml`：部署 `main` 和 `release`。
+  - `.github/workflows/release-manager.yml`：编排版本准备、release PR、腾讯云部署验证和 GitHub Release 发布。
 
 ## 服务器环境变量
 
@@ -35,6 +36,10 @@ main 分支    -> /srv/meteortest         -> 127.0.0.1:3201 -> mt-pre.jcmeteor.c
 不要提交真实值。部署 workflow 会在构建和启动 Next.js 前读取这个文件。
 
 ## 发布流程
+
+正常发布使用 `GitHub -> Actions -> Release Manager -> Run workflow`，选择 `action=full`。自动化细节和中断恢复命令见 `docs/release-manager.md`。
+
+底层发布流程是：
 
 1. 功能变更先合入 `main`。
 2. `main` 自动部署到预发入口：

--- a/scripts/release-manager.mjs
+++ b/scripts/release-manager.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)))
+
+const config = {
+  repo: 'JunchenMeteor/MeteorTest',
+  projectName: 'MeteorTest',
+  branchPrefix: 'dev/v-peq/release',
+  issuePrefix: '[Feature]',
+  issueLabel: 'enhancement',
+  versionFiles: ['apps/web/package.json', 'apps/web/package-lock.json'],
+  releaseDoc: (version) => `docs/releases/v${version}.md`,
+  releaseUrls: ['https://meteortest.jcmeteor.com/', 'https://mt-pre.jcmeteor.com/'],
+  deployWorkflow: 'Deploy Tencent',
+}
+
+const args = process.argv.slice(2)
+const command = args[0] ?? 'help'
+const options = parseOptions(args.slice(1))
+
+if (command === 'help' || options.help) {
+  printHelp()
+  process.exit(command === 'help' ? 0 : 1)
+}
+
+const version = normalizeVersion(options.version)
+const tag = `v${version}`
+const prepareTitle = `${config.issuePrefix} Prepare ${tag} release`
+const releaseTitle = `${config.issuePrefix} Release ${tag}`
+const dryRun = options.dryRun === true
+
+switch (command) {
+  case 'full':
+    await fullRelease()
+    break
+  case 'prepare':
+    await prepareRelease()
+    break
+  case 'promote':
+    await promoteRelease()
+    break
+  case 'verify':
+    await verifyRelease()
+    break
+  default:
+    fail(`Unknown command: ${command}`)
+}
+
+async function fullRelease() {
+  await prepareRelease()
+  await promoteRelease()
+  await verifyRelease()
+}
+
+async function prepareRelease() {
+  ensureTooling()
+  ensureCleanWorktree()
+  fetchBase()
+  ensureTagDoesNotExist(tag)
+
+  if (mainAlreadyPrepared(version)) {
+    log(`main already contains ${tag}; skipping preparation PR`)
+    return
+  }
+
+  const issue = createOrFindIssue(prepareTitle, issueBody('Prepare release version files and release notes.'))
+  const branch = `${config.branchPrefix}${tag.replaceAll('.', '')}`
+
+  run('git', ['checkout', '-B', branch, 'origin/main'])
+  updateVersionFiles(version)
+  writeReleaseDoc(version)
+
+  run('git', ['add', ...config.versionFiles.filter(exists), config.releaseDoc(version)])
+  run('git', ['commit', '-m', `Prepare ${tag} release`])
+  run('git', ['push', '-u', 'origin', branch])
+
+  const pr = createOrFindPr(prepareTitle, branch, 'main', prBody(issue.number, 'Prepare the release version files and release notes.'))
+  waitForPrChecks(pr.number)
+  mergePr(pr.number, true)
+  log(`Prepared ${tag} on main through PR #${pr.number}`)
+}
+
+async function promoteRelease() {
+  ensureTooling()
+  fetchBase()
+  ensureTagDoesNotExist(tag)
+
+  const issue = createOrFindIssue(releaseTitle, issueBody('Promote main to release and publish the GitHub Release.'))
+  const pr = createOrFindPr(releaseTitle, 'main', 'release', prBody(issue.number, 'Promote main to the protected production release branch.'))
+
+  waitForPrChecks(pr.number)
+  const mergeCommit = mergePr(pr.number, false)
+  waitForDeploy('release', mergeCommit)
+  createGithubRelease(tag, mergeCommit)
+  closeIssue(issue.number)
+  log(`Released ${tag}: https://github.com/${config.repo}/releases/tag/${tag}`)
+}
+
+async function verifyRelease() {
+  for (const url of config.releaseUrls) {
+    run('curl', ['-I', '--max-time', '15', url])
+  }
+}
+
+function parseOptions(rawArgs) {
+  const parsed = {}
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2).replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+    const next = rawArgs[index + 1]
+    if (!next || next.startsWith('--')) {
+      parsed[key] = true
+    } else {
+      parsed[key] = next
+      index += 1
+    }
+  }
+  return parsed
+}
+
+function normalizeVersion(value) {
+  if (!value || typeof value !== 'string') {
+    fail('Missing --version, for example: --version 0.1.3')
+  }
+  const normalized = value.replace(/^v/, '')
+  if (!/^\d+\.\d+\.\d+$/.test(normalized)) {
+    fail(`Invalid version "${value}". Use semver like 0.1.3.`)
+  }
+  return normalized
+}
+
+function ensureTooling() {
+  run('git', ['--version'])
+  run('gh', ['--version'])
+  run('curl', ['--version'])
+  run('git', ['config', 'user.name', 'github-actions[bot]'], { allowFail: true })
+  run('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'], { allowFail: true })
+}
+
+function ensureCleanWorktree() {
+  const status = capture('git', ['status', '--porcelain'])
+  if (status.trim()) fail(`Worktree is not clean:\n${status}`)
+}
+
+function fetchBase() {
+  run('git', ['fetch', 'origin', 'main', 'release', '--tags'])
+}
+
+function ensureTagDoesNotExist(tagName) {
+  const existing = capture('git', ['tag', '--list', tagName]).trim()
+  if (existing) fail(`Tag ${tagName} already exists.`)
+}
+
+function mainAlreadyPrepared(targetVersion) {
+  run('git', ['checkout', 'origin/main'])
+  return readJson('apps/web/package.json').version === targetVersion && existsSync(config.releaseDoc(targetVersion))
+}
+
+function updateVersionFiles(targetVersion) {
+  for (const file of config.versionFiles) {
+    if (!existsSync(file)) continue
+    const json = readJson(file)
+    if (file.endsWith('package-lock.json')) {
+      json.version = targetVersion
+      if (json.packages?.['']) json.packages[''].version = targetVersion
+    } else {
+      json.version = targetVersion
+    }
+    writeJson(file, json)
+  }
+}
+
+function writeReleaseDoc(targetVersion) {
+  const file = config.releaseDoc(targetVersion)
+  if (existsSync(file)) return
+  writeFileSync(
+    file,
+    `# Release Notes
+
+Release focus: production promotion for ${config.projectName} ${targetVersion}.
+
+## Highlights
+
+- Promoted validated main branch changes to the production release branch.
+- Updated Web package version to \`${targetVersion}\`.
+- Published GitHub Release tag \`v${targetVersion}\`.
+
+## Deployment
+
+- Production branch: \`release\`
+- Preview branch: \`main\`
+- Production URL: \`https://meteortest.jcmeteor.com/\`
+- Preview URL: \`https://mt-pre.jcmeteor.com/\`
+
+## Versioning
+
+- Web version: \`${targetVersion}\`
+- Release tag: \`v${targetVersion}\`
+
+## Validation
+
+\`\`\`bash
+cd apps/web
+npm run lint
+npm run build
+\`\`\`
+`,
+  )
+}
+
+function createOrFindIssue(title, body) {
+  const existing = JSON.parse(capture('gh', ['issue', 'list', '--repo', config.repo, '--state', 'all', '--search', `${JSON.stringify(title)} in:title`, '--json', 'number,title,state,url', '--limit', '20']))
+    .find((issue) => issue.title === title)
+  if (existing) return existing
+
+  if (dryRun) return { number: 0, title, url: 'dry-run' }
+  const output = capture('gh', ['issue', 'create', '--repo', config.repo, '--title', title, '--body', body, '--label', config.issueLabel])
+  return parseIssueUrl(output.trim())
+}
+
+function createOrFindPr(title, head, base, body) {
+  const existing = JSON.parse(capture('gh', ['pr', 'list', '--repo', config.repo, '--state', 'open', '--head', head, '--base', base, '--json', 'number,title,url', '--limit', '20']))
+    .find((pr) => pr.title === title)
+  if (existing) return existing
+
+  if (dryRun) return { number: 0, title, url: 'dry-run' }
+  const output = capture('gh', ['pr', 'create', '--repo', config.repo, '--title', title, '--body', body, '--head', head, '--base', base])
+  return parsePrUrl(output.trim())
+}
+
+function waitForPrChecks(number) {
+  if (dryRun) return
+  run('gh', ['pr', 'checks', String(number), '--repo', config.repo, '--watch'])
+}
+
+function mergePr(number, deleteBranch) {
+  if (dryRun) return capture('git', ['rev-parse', 'origin/main']).trim()
+  const args = ['pr', 'merge', String(number), '--repo', config.repo, '--merge']
+  if (deleteBranch) args.push('--delete-branch')
+  run('gh', args)
+  const pr = JSON.parse(capture('gh', ['pr', 'view', String(number), '--repo', config.repo, '--json', 'mergeCommit']))
+  return pr.mergeCommit?.oid ?? ''
+}
+
+function waitForDeploy(branch, headSha) {
+  if (dryRun) return
+  const startedAt = Date.now()
+  for (;;) {
+    const runs = JSON.parse(capture('gh', ['run', 'list', '--repo', config.repo, '--branch', branch, '--workflow', config.deployWorkflow, '--json', 'databaseId,status,conclusion,headSha,createdAt', '--limit', '10']))
+    const runInfo = runs.find((item) => item.headSha === headSha) ?? runs[0]
+    if (runInfo?.status === 'completed') {
+      if (runInfo.conclusion !== 'success') fail(`${config.deployWorkflow} failed with conclusion: ${runInfo.conclusion}`)
+      return
+    }
+    if (Date.now() - startedAt > 20 * 60 * 1000) fail(`Timed out waiting for ${config.deployWorkflow}`)
+    log(`Waiting for ${config.deployWorkflow} on ${branch}...`)
+    sleep(15_000)
+  }
+}
+
+function createGithubRelease(tagName, target) {
+  if (dryRun) return
+  const existing = capture('gh', ['release', 'list', '--repo', config.repo, '--json', 'tagName', '--limit', '100'])
+  if (JSON.parse(existing).some((release) => release.tagName === tagName)) return
+  run('gh', ['release', 'create', tagName, '--repo', config.repo, '--target', target, '--title', tagName, '--notes-file', config.releaseDoc(version), '--latest'])
+}
+
+function closeIssue(number) {
+  if (dryRun || number === 0) return
+  const issue = JSON.parse(capture('gh', ['issue', 'view', String(number), '--repo', config.repo, '--json', 'state']))
+  if (issue.state !== 'CLOSED') {
+    run('gh', ['issue', 'close', String(number), '--repo', config.repo, '--comment', `Released ${tag}: https://github.com/${config.repo}/releases/tag/${tag}`])
+  }
+}
+
+function issueBody(summary) {
+  return `## Summary
+
+${summary}
+
+## Expected Behavior
+
+The release is promoted from main to release through protected PR checks, deployed to Tencent production, and published as a GitHub Release.
+
+## Proposed Changes
+
+- Update release version files and release notes when needed.
+- Promote main to release through a pull request.
+- Wait for deployment validation before publishing the GitHub Release.
+
+## Test Plan
+
+- Automated Release Manager PR checks.
+- Tencent release deployment workflow.
+- Production URL verification.`
+}
+
+function prBody(issueNumber, summary) {
+  return `## Summary
+
+${summary}
+
+## Test Plan
+
+- Automated CI, build, CodeQL, and deployment checks.
+- Release Manager verification.
+
+Closes #${issueNumber}`
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function exists(file) {
+  return existsSync(file)
+}
+
+function parseIssueUrl(url) {
+  const match = url.match(/issues\/(\d+)/)
+  if (!match) fail(`Could not parse issue URL: ${url}`)
+  return { number: Number(match[1]), url }
+}
+
+function parsePrUrl(url) {
+  const match = url.match(/pull\/(\d+)/)
+  if (!match) fail(`Could not parse PR URL: ${url}`)
+  return { number: Number(match[1]), url }
+}
+
+function capture(commandName, commandArgs) {
+  return run(commandName, commandArgs, { capture: true })
+}
+
+function run(commandName, commandArgs, options = {}) {
+  const printable = `${commandName} ${commandArgs.join(' ')}`
+  log(printable)
+  if (dryRun && !options.capture && !['git', 'gh'].includes(commandName)) return ''
+  try {
+    return execFileSync(commandName, commandArgs, {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+    })
+  } catch (error) {
+    if (options.allowFail) return ''
+    const stderr = error.stderr?.toString?.() ?? ''
+    fail(`${printable} failed${stderr ? `:\n${stderr}` : ''}`)
+  }
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+function log(message) {
+  console.log(`[release-manager] ${message}`)
+}
+
+function fail(message) {
+  console.error(`[release-manager] ${message}`)
+  process.exit(1)
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/release-manager.mjs full --version 0.1.3
+  node scripts/release-manager.mjs prepare --version 0.1.3
+  node scripts/release-manager.mjs promote --version 0.1.3
+  node scripts/release-manager.mjs verify --version 0.1.3`)
+}


### PR DESCRIPTION
## Summary

Add a GitHub Actions Release Manager workflow backed by a repository script so production releases can be run from one manual action.

## Test Plan

- node --check scripts/release-manager.mjs
- node scripts/release-manager.mjs help
- npm run lint
- npm run build

Closes #125