### PR TITLE
fix(deploy): use regional npm registry on Tencent

### DIFF
--- a/.github/workflows/deploy-tencent.yml
+++ b/.github/workflows/deploy-tencent.yml
@@ -94,7 +94,12 @@ jobs:
           fi
 
       - name: Build image from artifact
-        run: docker build --tag "meteortest-web:${GITHUB_SHA}" --file source/apps/web/Dockerfile source/apps/web
+        run: >-
+          docker build
+          --build-arg NPM_REGISTRY=https://registry.npmmirror.com
+          --tag "meteortest-web:${GITHUB_SHA}"
+          --file source/apps/web/Dockerfile
+          source/apps/web
 
       - name: Deploy
         env:

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:24-bookworm-slim AS dependencies
 
 WORKDIR /app
+ARG NPM_REGISTRY=https://registry.npmjs.org
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --registry="${NPM_REGISTRY}"
 
 FROM dependencies AS builder
 


### PR DESCRIPTION
Closes #133\n\nKeeps npmjs as the portable Dockerfile default and passes npmmirror only for Tencent runner builds.