### PR TITLE
fix(deploy): isolate Compose deployment variables

### DIFF
--- a/deploy/deploy-container.sh
+++ b/deploy/deploy-container.sh
@@ -34,7 +34,8 @@ compose() {
   local project="$1"
   local env_file="$2"
   shift 2
-  docker compose --project-name "${project}" --env-file "${env_file}" --file "${compose_file}" "$@"
+  env -u IMAGE_URI -u HOST_PORT -u RUNTIME_ENV_FILE \
+    docker compose --project-name "${project}" --env-file "${env_file}" --file "${compose_file}" "$@"
 }
 
 wait_for_health() {


### PR DESCRIPTION
Closes #135\n\nUnsets workflow-level deployment variables for Compose invocations so explicit shadow/final env files control their own ports and images.