### PR TITLE
fix(release): require exact deployment SHA

### DIFF
--- a/scripts/release-manager.mjs
+++ b/scripts/release-manager.mjs
@@ -252,7 +252,7 @@ function waitForDeploy(branch, headSha) {
   const startedAt = Date.now()
   for (;;) {
     const runs = JSON.parse(capture('gh', ['run', 'list', '--repo', config.repo, '--branch', branch, '--workflow', config.deployWorkflow, '--json', 'databaseId,status,conclusion,headSha,createdAt', '--limit', '10']))
-    const runInfo = runs.find((item) => item.headSha === headSha) ?? runs[0]
+    const runInfo = runs.find((item) => item.headSha === headSha)
     if (runInfo?.status === 'completed') {
       if (runInfo.conclusion !== 'success') fail(`${config.deployWorkflow} failed with conclusion: ${runInfo.conclusion}`)
       return


### PR DESCRIPTION
Closes #144\n\nWaits until a deployment run exists for the exact release merge commit; older successful runs can no longer authorize a GitHub Release.