### PR TITLE
[Feature] Require human Git authors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,8 @@ Use fresh GitHub data when checking issue or PR state. Prefer `gh api --cache 0s
 
 Do not add `Co-Authored-By` or AI attribution to commit messages.
 
+Git authors and committers must use an approved human identity (`Connor`, `ConnorQi`, or `JunchenMeteor`). Bot, automation, AI-tool, and agent identities such as `github-actions[bot]` are forbidden. Automated commits must use `JunchenMeteor <15767428+JunchenMeteor@users.noreply.github.com>`.
+
 ## Security And Secrets
 
 Never commit or print real values for:

--- a/scripts/release-manager.mjs
+++ b/scripts/release-manager.mjs
@@ -138,8 +138,8 @@ function ensureTooling() {
   run('git', ['--version'])
   run('gh', ['--version'])
   run('curl', ['--version'])
-  run('git', ['config', 'user.name', 'github-actions[bot]'], { allowFail: true })
-  run('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'], { allowFail: true })
+  run('git', ['config', 'user.name', 'JunchenMeteor'], { allowFail: true })
+  run('git', ['config', 'user.email', '15767428+JunchenMeteor@users.noreply.github.com'], { allowFail: true })
 }
 
 function ensureCleanWorktree() {


### PR DESCRIPTION
## Summary

Prevent bot, automation, AI-tool, and agent identities from appearing as Git authors or committers.

## Proposed Changes

- Add the approved-human-identity rule to `AGENTS.md`.
- Configure Release Manager commits as `JunchenMeteor <15767428+JunchenMeteor@users.noreply.github.com>`.

## Test Plan

- `node --check scripts/release-manager.mjs`
- Confirmed the release manager no longer configures `github-actions[bot]`.
- CI and Vercel checks passed.

Closes #148